### PR TITLE
Improve handling of NullStmts

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -129,16 +129,18 @@ func Parse(line string) interface{} {
 		node = parseVarDecl(line)
 	case "WhileStmt":
 		node = parseWhileStmt(line)
+	case "NullStmt":
+		node = nil
 	default:
-		panic("'" + line + "'")
+		panic("Unknown node type: '" + line + "'")
 	}
 
 	return node
 }
 
 func groupsFromRegex(rx, line string) map[string]string {
-	// We remove tabs and newlines from the regex. This is purely cosmetic
-	// as the regex input can be quite lone and its nice for the caller to
+	// We remove tabs and newlines from the regex. This is purely cosmetic,
+	// as the regex input can be quite long and it's nice for the caller to
 	// be able to format it in a more readable way.
 	fullRegexp := "(?P<address>[0-9a-fx]+) " +
 		strings.Replace(strings.Replace(rx, "\n", "", -1), "\t", "", -1)

--- a/common.go
+++ b/common.go
@@ -11,6 +11,9 @@ func printLine(out *bytes.Buffer, line string, indent int) {
 }
 
 func renderExpression(node interface{}) []string {
+	if node == nil {
+		return []string{""}
+	}
 	if n, ok := node.(ExpressionRenderer); ok {
 		return n.Render()
 	}

--- a/for_stmt.go
+++ b/for_stmt.go
@@ -28,12 +28,21 @@ func (n *ForStmt) RenderLine(out *bytes.Buffer, functionName string, indent int,
 	children := n.Children
 
 	a := renderExpression(children[0])[0]
-	b := renderExpression(children[1])[0]
-	c := renderExpression(children[2])[0]
+	// TODO: The second child of a ForStmt appears to always be null.
+	// Are there any cases where it is used?
+	if children[1] != nil {
+		panic("non-nil child 1 in ForStmt")
+	}
+	b := renderExpression(children[2])[0]
+	c := renderExpression(children[3])[0]
 
-	printLine(out, fmt.Sprintf("for %s; %s; %s {", a, b, c), indent)
+	if a == "" && b == "" && c == "" {
+		printLine(out, fmt.Sprintf("for {"), indent)
+	} else {
+		printLine(out, fmt.Sprintf("for %s; %s; %s {", a, b, c), indent)
+	}
 
-	Render(out, children[3], functionName, indent+1, returnType)
+	Render(out, children[4], functionName, indent+1, returnType)
 
 	printLine(out, "}", indent)
 }

--- a/if_stmt.go
+++ b/if_stmt.go
@@ -25,7 +25,8 @@ func parseIfStmt(line string) *IfStmt {
 }
 
 func (n *IfStmt) RenderLine(out *bytes.Buffer, functionName string, indent int, returnType string) {
-	// XXX: the first two children of an IfStmt appear to always be null.
+	// TODO: The first two children of an IfStmt appear to always be null.
+	// Are there any cases where they are used?
 	children := n.Children[2:]
 
 	e := renderExpression(children[0])

--- a/if_stmt.go
+++ b/if_stmt.go
@@ -25,7 +25,8 @@ func parseIfStmt(line string) *IfStmt {
 }
 
 func (n *IfStmt) RenderLine(out *bytes.Buffer, functionName string, indent int, returnType string) {
-	children := n.Children
+	// XXX: the first two children of an IfStmt appear to always be null.
+	children := n.Children[2:]
 
 	e := renderExpression(children[0])
 	printLine(out, fmt.Sprintf("if %s {", cast(e[0], e[1], "bool")), indent)

--- a/main.go
+++ b/main.go
@@ -23,15 +23,14 @@ func convertLinesToNodes(lines []string) []interface{} {
 			continue
 		}
 
-		// This will need to be handled more gracefully... I'm not even
-		// sure what this means?
-		if strings.Index(line, "<<<NULL>>>") >= 0 {
-			continue
-		}
+		// It is tempting to discard null AST nodes, but these may
+		// have semantic importance: for example, they represent omitted
+		// for-loop conditions, as in for(;;).
+		line = strings.Replace(line, "<<<NULL>>>", "NullStmt", 1)
 
 		indentAndType := regexp.MustCompile("^([|\\- `]*)(\\w+)").FindStringSubmatch(line)
 		if len(indentAndType) == 0 {
-			panic(fmt.Sprintf("Can not understand line '%s'", line))
+			panic(fmt.Sprintf("Cannot understand line '%s'", line))
 		}
 
 		offset := len(indentAndType[1])

--- a/tests/misc/for.c
+++ b/tests/misc/for.c
@@ -2,10 +2,15 @@
 
 int main()
 {
-   int i;
-   for (i = 0; i < 10; i++)
-	printf("%d\n", i);
+    int i;
+    for (i = 0; i < 10; i++)
+        printf("%d\n", i);
 
-   for (;;)
-        printf("infinite loop");
+    int j = 0;
+    for (;;) {
+        printf("infinite loop\n");
+        j++;
+        if (j > 10)
+            break;
+    }
 }

--- a/tests/misc/for.c
+++ b/tests/misc/for.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main()
+{
+   int i;
+   for (i = 0; i < 10; i++)
+	printf("%d\n", i);
+
+   for (;;)
+        printf("infinite loop");
+}

--- a/while_stmt.go
+++ b/while_stmt.go
@@ -25,7 +25,9 @@ func parseWhileStmt(line string) *WhileStmt {
 }
 
 func (n *WhileStmt) RenderLine(out *bytes.Buffer, functionName string, indent int, returnType string) {
-	children := n.Children
+	// TODO: The first child of a WhileStmt appears to always be null.
+	// Are there any cases where it is used?
+	children := n.Children[1:]
 
 	e := renderExpression(children[0])
 	printLine(out, fmt.Sprintf("for %s {", cast(e[0], e[1], "bool")), indent)


### PR DESCRIPTION
There are still some unanswered questions here - I'm not sure why there always seems to be 2 extra null children in each IfStmt, and and extra null child in each ForStmt and WhileStmt. This does however fix handling of for(;;) loops.

I also added a -print-ast flag for debugging purposes, and added a usage message if c2go is invoked incorrectly.

Fixes #29 and adds a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/33)
<!-- Reviewable:end -->
