### PR TITLE
Issue #26

### DIFF
--- a/ast_test.go
+++ b/ast_test.go
@@ -856,6 +856,18 @@ var nodes = map[string]interface{}{
 		IsReferenced: false,
 		Children:     []interface{}{},
 	},
+	// Issue: #26
+	`0x55b9da8784b0 <line:341:1, line:342:16> line:341:19 __io_write_fn '__ssize_t (void *, const char *, size_t)'`: &TypedefDecl{
+		Address:      "0x55b9da8784b0",
+		Position:     "line:341:1, line:342:16",
+		Position2:    "line:341:19",
+		Name:         "__io_write_fn",
+		Type:         "__ssize_t (void *, const char *, size_t)",
+		Type2:        "",
+		IsImplicit:   false,
+		IsReferenced: false,
+		Children:     []interface{}{},
+	},
 
 	// TypedefType
 	`0x7f887a0dc760 '__uint16_t' sugar`: &TypedefType{

--- a/typedef_decl.go
+++ b/typedef_decl.go
@@ -21,7 +21,7 @@ type TypedefDecl struct {
 func parseTypedefDecl(line string) *TypedefDecl {
 	groups := groupsFromRegex(
 		`<(?P<position><invalid sloc>|.*?)>
-		(?P<position2> <invalid sloc>| col:\d+)?
+		(?P<position2> <invalid sloc>| col:\d+| line:\d+:\d+)?
 		(?P<implicit> implicit)?
 		(?P<referenced> referenced)?
 		(?P<name> \w+)?


### PR DESCRIPTION
This fixes issue #26 were TypedefDecl wasn't parsed correctly in the case were position 2 is in the form: `line:\d+:\d+`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/34)
<!-- Reviewable:end -->
