### PR TITLE
Simple patch to enforce argument for file path

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,6 +120,13 @@ func Check(e error) {
 }
 
 func Start(args []string) string {
+
+        // Need at least one argument for C file path 
+        if len(args) < 2 {
+        fmt.Fprintf(os.Stderr, "Usage: %s tests/misc/prime.c > /tmp/prime.go\n", args[0])
+        os.Exit(1)
+        }
+
 	if os.Getenv("GOPATH") == "" {
 		panic("The $GOPATH must be set.")
 	}


### PR DESCRIPTION
Feel free to reject to this pull request and use your own approach. This is just an quick fix without using flag package.

Before:
```
[me@os03 c2go]$ ./c2go
panic: runtime error: index out of range

goroutine 1 [running]:
main.Start(0xc42000e210, 0x1, 0x1, 0x0, 0x0)
        /home/me/ws/c2go/main.go:128 +0x5f7
main.main()
        /home/me/ws/c2go/main.go:171 +0x49
[me@os03 c2go]$
```
After:
```
[me@os03 c2go]$ ./c2go
Usage: ./c2go tests/misc/prime.c > /tmp/prime.go
[me@os03 c2go]$
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/36)
<!-- Reviewable:end -->
