### PR TITLE
Handle special character literals. Fixes #80

### DIFF
--- a/transpiler/literals.go
+++ b/transpiler/literals.go
@@ -37,20 +37,9 @@ func transpileIntegerLiteral(n *ast.IntegerLiteral) *goast.BasicLit {
 }
 
 func transpileCharacterLiteral(n *ast.CharacterLiteral) *goast.BasicLit {
-	var s string
-
-	// TODO: Transpile special character literals
-	// https://github.com/elliotchance/c2go/issues/80
-	switch n.Value {
-	case '\n':
-		s = "\\n"
-	default:
-		s = fmt.Sprintf("%c", n.Value)
-	}
-
 	return &goast.BasicLit{
 		Kind:  token.CHAR,
-		Value: fmt.Sprintf("'%s'", s),
+		Value: fmt.Sprintf("%q", n.Value),
 	}
 }
 

--- a/transpiler/literals_test.go
+++ b/transpiler/literals_test.go
@@ -1,0 +1,57 @@
+package transpiler
+
+import (
+	"reflect"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/elliotchance/c2go/ast"
+	goast "go/ast"
+	"go/token"
+)
+
+var chartests = []struct {
+	in  int    // Integer Character Code
+	out string // Output Character Literal
+}{
+	// NUL byte
+	{0, "'\\x00'"},
+
+	// ASCII control characters
+	{7, "'\\a'"},
+	{8, "'\\b'"},
+	{9, "'\\t'"},
+	{10, "'\\n'"},
+	{11, "'\\v'"},
+	{12, "'\\f'"},
+	{13, "'\\r'"},
+
+	// printable ASCII
+	{32, "' '"},
+	{34, "'\"'"},
+	{39, "'\\''"},
+	{65, "'A'"},
+	{92, "'\\\\'"},
+	{191, "'¿'"},
+
+	// printable unicode
+	{948, "'δ'"},
+	{0x03a9, "'Ω'"},
+	{0x2020, "'†'"},
+
+	// non-printable unicode
+	{0xffff, "'\\uffff'"},
+	{utf8.MaxRune, "'\\U0010ffff'"},
+}
+
+func TestCharacterLiterals(t *testing.T) {
+	for _, tt := range chartests {
+		expected := &goast.BasicLit{Kind: token.CHAR, Value: tt.out}
+		actual := transpileCharacterLiteral(&ast.CharacterLiteral{Value: tt.in})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("input: %v", tt.in)
+			t.Errorf("  expected: %v", expected)
+			t.Errorf("  actual:   %v", actual)
+		}
+	}
+}


### PR DESCRIPTION
I think that %q will handle translating the integer to the correct char literal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/82)
<!-- Reviewable:end -->
