### PR TITLE
Handle 'referenced' in EnumConstantDecl

### DIFF
--- a/ast/enum_constant_decl.go
+++ b/ast/enum_constant_decl.go
@@ -7,30 +7,33 @@ import (
 )
 
 type EnumConstantDecl struct {
-	Address   string
-	Position  string
-	Position2 string
-	Name      string
-	Type      string
-	Children  []Node
+	Address    string
+	Position   string
+	Position2  string
+	Referenced bool
+	Name       string
+	Type       string
+	Children   []Node
 }
 
 func parseEnumConstantDecl(line string) *EnumConstantDecl {
 	groups := groupsFromRegex(
 		`<(?P<position>.*)>
-		(?P<position2> [^ ]+)?
+		( (?P<position2>[^ ]+))?
+		( (?P<referenced>referenced))?
 		 (?P<name>.+)
 		 '(?P<type>.+?)'`,
 		line,
 	)
 
 	return &EnumConstantDecl{
-		Address:   groups["address"],
-		Position:  groups["position"],
-		Position2: groups["position2"],
-		Name:      groups["name"],
-		Type:      groups["type"],
-		Children:  []Node{},
+		Address:    groups["address"],
+		Position:   groups["position"],
+		Position2:  groups["position2"],
+		Referenced: len(groups["referenced"]) > 0,
+		Name:       groups["name"],
+		Type:       groups["type"],
+		Children:   []Node{},
 	}
 }
 

--- a/ast/enum_constant_decl_test.go
+++ b/ast/enum_constant_decl_test.go
@@ -7,12 +7,22 @@ import (
 func TestEnumConstantDecl(t *testing.T) {
 	nodes := map[string]Node{
 		`0x1660db0 <line:185:3> __codecvt_noconv 'int'`: &EnumConstantDecl{
-			Address:   "0x1660db0",
-			Position:  "line:185:3",
-			Position2: "",
-			Name:      "__codecvt_noconv",
-			Type:      "int",
-			Children:  []Node{},
+			Address:    "0x1660db0",
+			Position:   "line:185:3",
+			Position2:  "",
+			Referenced: false,
+			Name:       "__codecvt_noconv",
+			Type:       "int",
+			Children:   []Node{},
+		},
+		`0x3c77ba8 <line:59:3, col:65> col:3 referenced _ISalnum 'int'`: &EnumConstantDecl{
+			Address:    "0x3c77ba8",
+			Position:   "line:59:3, col:65",
+			Position2:  "col:3",
+			Referenced: true,
+			Name:       "_ISalnum",
+			Type:       "int",
+			Children:   []Node{},
 		},
 	}
 


### PR DESCRIPTION
I'm not sure why, but the `ctype.c` integration test fails for me on my clang v3.8.0 due to `"referenced"` showing up in the `EnumConstantDecl` AST nodes. Updated the regex to handle it and added a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/87)
<!-- Reviewable:end -->
