### PR TITLE
More sane error reporting

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@
 package ast
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -9,6 +10,184 @@ import (
 // Node represents any node in the AST.
 type Node interface {
 	AddChild(node Node)
+}
+
+// Position returns the position of the node in the original file. If the
+// position cannot be dtermined an empty string is returned.
+func Position(node Node) string {
+	switch n := node.(type) {
+	case *AlignedAttr:
+		return n.Position
+	case *AlwaysInlineAttr:
+		return n.Position
+	case *ArraySubscriptExpr:
+		return n.Position
+	case *AsmLabelAttr:
+		return n.Position
+	case *AvailabilityAttr:
+		return n.Position
+	case *BinaryOperator:
+		return n.Position
+	case *BreakStmt:
+		return n.Position
+	case *BuiltinType:
+		return ""
+	case *CallExpr:
+		return n.Position
+	case *CaseStmt:
+		return n.Position
+	case *CharacterLiteral:
+		return n.Position
+	case *CompoundStmt:
+		return n.Position
+	case *ConditionalOperator:
+		return n.Position
+	case *ConstAttr:
+		return n.Position
+	case *ConstantArrayType:
+		return ""
+	case *ContinueStmt:
+		return n.Position
+	case *CompoundAssignOperator:
+		return n.Position
+	case *CStyleCastExpr:
+		return n.Position
+	case *DeclRefExpr:
+		return n.Position
+	case *DeclStmt:
+		return n.Position
+	case *DefaultStmt:
+		return n.Position
+	case *DeprecatedAttr:
+		return n.Position
+	case *DoStmt:
+		return n.Position
+	case *ElaboratedType:
+		return ""
+	case *Enum:
+		return ""
+	case *EnumConstantDecl:
+		return n.Position
+	case *EnumDecl:
+		return n.Position
+	case *EnumType:
+		return ""
+	case *FieldDecl:
+		return n.Position
+	case *FloatingLiteral:
+		return n.Position
+	case *FormatAttr:
+		return n.Position
+	case *FunctionDecl:
+		return n.Position
+	case *FunctionProtoType:
+		return ""
+	case *ForStmt:
+		return n.Position
+	case *GotoStmt:
+		return n.Position
+	case *IfStmt:
+		return n.Position
+	case *ImplicitCastExpr:
+		return n.Position
+	case *ImplicitValueInitExpr:
+		return n.Position
+	case *IncompleteArrayType:
+		return ""
+	case *InitListExpr:
+		return n.Position
+	case *IntegerLiteral:
+		return n.Position
+	case *LabelStmt:
+		return n.Position
+	case *MallocAttr:
+		return n.Position
+	case *MaxFieldAlignmentAttr:
+		return n.Position
+	case *MemberExpr:
+		return n.Position
+	case *ModeAttr:
+		return n.Position
+	case *NoInlineAttr:
+		return n.Position
+	case *NoThrowAttr:
+		return n.Position
+	case *NonNullAttr:
+		return n.Position
+	case *OffsetOfExpr:
+		return n.Position
+	case *PackedAttr:
+		return n.Position
+	case *ParenExpr:
+		return n.Position
+	case *ParenType:
+		return ""
+	case *ParmVarDecl:
+		return n.Position
+	case *PointerType:
+		return ""
+	case *PredefinedExpr:
+		return n.Position
+	case *PureAttr:
+		return n.Position
+	case *QualType:
+		return ""
+	case *Record:
+		return ""
+	case *RecordDecl:
+		return n.Position
+	case *RecordType:
+		return ""
+	case *RestrictAttr:
+		return n.Position
+	case *ReturnStmt:
+		return n.Position
+	case *ReturnsTwiceAttr:
+		return n.Position
+	case *StringLiteral:
+		return n.Position
+	case *SwitchStmt:
+		return n.Position
+	case *TranslationUnitDecl:
+		return ""
+	case *TransparentUnionAttr:
+		return n.Position
+	case *Typedef:
+		return ""
+	case *TypedefDecl:
+		return n.Position
+	case *TypedefType:
+		return ""
+	case *UnaryExprOrTypeTraitExpr:
+		return n.Position
+	case *UnaryOperator:
+		return n.Position
+	case *VAArgExpr:
+		return n.Position
+	case *VarDecl:
+		return n.Position
+	case *WarnUnusedResultAttr:
+		return n.Position
+	case *WhileStmt:
+		return n.Position
+	default:
+		panic(n)
+	}
+}
+
+func Error(e error, n Node) {
+	if e != nil {
+		fmt.Printf("// ERROR: %s: %s\n", Position(n), e.Error())
+		panic(e)
+	}
+}
+
+func Warning(e error, n Node) bool {
+	if e != nil {
+		fmt.Printf("// WARNING: %s: %s\n", Position(n), e.Error())
+	}
+
+	return e != nil
 }
 
 // Parse takes the coloured output of the clang AST command and returns a root

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -14,7 +14,7 @@ type Node interface {
 }
 
 // Position returns the position of the node in the original file. If the
-// position cannot be dtermined an empty string is returned.
+// position cannot be determined an empty string is returned.
 func Position(node Node) string {
 	switch n := node.(type) {
 	case *AlignedAttr:

--- a/program/struct.go
+++ b/program/struct.go
@@ -28,6 +28,9 @@ func NewStruct(n *ast.RecordDecl) *Struct {
 		case *ast.RecordDecl:
 			fields[f.Name] = NewStruct(f)
 
+		case *ast.MaxFieldAlignmentAttr, *ast.AlignedAttr:
+			// FIXME: Should these really be ignored?
+
 		default:
 			panic(fmt.Sprintf("cannot decode: %#v", f))
 		}

--- a/transpiler/binary.go
+++ b/transpiler/binary.go
@@ -38,15 +38,18 @@ func transpileBinaryOperator(n *ast.BinaryOperator, p *program.Program) (
 	if operator == token.LAND {
 		left, err = types.CastExpr(p, left, leftType, "bool")
 		ast.WarningOrError(err, n, left == nil)
+		if left == nil {
+			left = util.NewStringLit("nil")
+		}
 
 		right, err = types.CastExpr(p, right, rightType, "bool")
 		ast.WarningOrError(err, n, right == nil)
+		if right == nil {
+			right = util.NewStringLit("nil")
+		}
 
-		return &goast.BinaryExpr{
-			X:  left,
-			Op: operator,
-			Y:  right,
-		}, "bool", preStmts, postStmts, nil
+		return util.NewBinaryExpr(left, operator, right), "bool",
+			preStmts, postStmts, nil
 	}
 
 	// Convert "(0)" to "nil" when we are dealing with equality.
@@ -75,9 +78,7 @@ func transpileBinaryOperator(n *ast.BinaryOperator, p *program.Program) (
 		}
 	}
 
-	return &goast.BinaryExpr{
-		X:  left,
-		Op: operator,
-		Y:  right,
-	}, types.ResolveTypeForBinaryOperator(p, n.Operator, leftType, rightType), preStmts, postStmts, nil
+	return util.NewBinaryExpr(left, operator, right),
+		types.ResolveTypeForBinaryOperator(p, n.Operator, leftType, rightType),
+		preStmts, postStmts, nil
 }

--- a/transpiler/binary.go
+++ b/transpiler/binary.go
@@ -69,7 +69,10 @@ func transpileBinaryOperator(n *ast.BinaryOperator, p *program.Program) (
 
 	if operator == token.ASSIGN {
 		right, err = types.CastExpr(p, right, rightType, returnType)
-		ast.WarningOrError(err, n, right == nil)
+
+		if ast.IsWarning(err, n) {
+			right = util.NewStringLit("nil")
+		}
 	}
 
 	return &goast.BinaryExpr{

--- a/transpiler/binary.go
+++ b/transpiler/binary.go
@@ -73,7 +73,7 @@ func transpileBinaryOperator(n *ast.BinaryOperator, p *program.Program) (
 	if operator == token.ASSIGN {
 		right, err = types.CastExpr(p, right, rightType, returnType)
 
-		if ast.IsWarning(err, n) {
+		if ast.IsWarning(err, n) && right == nil {
 			right = util.NewStringLit("nil")
 		}
 	}

--- a/transpiler/binary.go
+++ b/transpiler/binary.go
@@ -16,6 +16,7 @@ func transpileBinaryOperator(n *ast.BinaryOperator, p *program.Program) (
 	*goast.BinaryExpr, string, []goast.Stmt, []goast.Stmt, error) {
 	preStmts := []goast.Stmt{}
 	postStmts := []goast.Stmt{}
+	var err error
 
 	left, leftType, newPre, newPost, err := transpileToExpr(n.Children[0], p)
 	if err != nil {
@@ -35,8 +36,11 @@ func transpileBinaryOperator(n *ast.BinaryOperator, p *program.Program) (
 	returnType := types.ResolveTypeForBinaryOperator(p, n.Operator, leftType, rightType)
 
 	if operator == token.LAND {
-		left = types.CastExpr(p, left, leftType, "bool")
-		right = types.CastExpr(p, right, rightType, "bool")
+		left, err = types.CastExpr(p, left, leftType, "bool")
+		ast.WarningOrError(err, n, left == nil)
+
+		right, err = types.CastExpr(p, right, rightType, "bool")
+		ast.WarningOrError(err, n, right == nil)
 
 		return &goast.BinaryExpr{
 			X:  left,
@@ -48,7 +52,10 @@ func transpileBinaryOperator(n *ast.BinaryOperator, p *program.Program) (
 	// Convert "(0)" to "nil" when we are dealing with equality.
 	if (operator == token.NEQ || operator == token.EQL) &&
 		types.IsNullExpr(right) {
-		if types.ResolveType(p, leftType) == "string" {
+		t, err := types.ResolveType(p, leftType)
+		ast.IsWarning(err, n)
+
+		if t == "string" {
 			p.AddImport("github.com/elliotchance/c2go/noarch")
 			left = util.NewCallExpr("noarch.NullTerminatedString", left)
 			right = &goast.BasicLit{
@@ -61,7 +68,8 @@ func transpileBinaryOperator(n *ast.BinaryOperator, p *program.Program) (
 	}
 
 	if operator == token.ASSIGN {
-		right = types.CastExpr(p, right, rightType, returnType)
+		right, err = types.CastExpr(p, right, rightType, returnType)
+		ast.WarningOrError(err, n, right == nil)
 	}
 
 	return &goast.BinaryExpr{

--- a/transpiler/branch.go
+++ b/transpiler/branch.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elliotchance/c2go/ast"
 	"github.com/elliotchance/c2go/program"
 	"github.com/elliotchance/c2go/types"
+	"github.com/elliotchance/c2go/util"
 
 	goast "go/ast"
 )
@@ -67,6 +68,10 @@ func transpileIfStmt(n *ast.IfStmt, p *program.Program) (
 	// The condition in Go must always be a bool.
 	boolCondition, err := types.CastExpr(p, conditional, conditionalType, "bool")
 	ast.WarningOrError(err, n, boolCondition == nil)
+
+	if boolCondition == nil {
+		boolCondition = util.NewStringLit("nil")
+	}
 
 	body, newPre, newPost, err := transpileToBlockStmt(children[2], p)
 	if err != nil {
@@ -160,6 +165,10 @@ func transpileForStmt(n *ast.ForStmt, p *program.Program) (
 
 		condition, err = types.CastExpr(p, condition, conditionType, "bool")
 		ast.WarningOrError(err, n, condition == nil)
+
+		if condition == nil {
+			condition = util.NewStringLit("nil")
+		}
 	}
 
 	return &goast.ForStmt{
@@ -196,6 +205,10 @@ func transpileWhileStmt(n *ast.WhileStmt, p *program.Program) (
 	cond, err := types.CastExpr(p, condition, conditionType, "bool")
 	ast.WarningOrError(err, n, cond == nil)
 
+	if cond == nil {
+		cond = util.NewStringLit("nil")
+	}
+
 	return &goast.ForStmt{
 		Cond: cond,
 		Body: body,
@@ -222,9 +235,13 @@ func transpileDoStmt(n *ast.DoStmt, p *program.Program) (
 
 	preStmts, postStmts = combinePreAndPostStmts(preStmts, postStmts, newPre, newPost)
 
-	// Add IfStmt to the end of the loop to check the condition
+	// Add IfStmt to the end of the loop to check the condition.
 	x, err := types.CastExpr(p, condition, conditionType, "bool")
 	ast.WarningOrError(err, n, x == nil)
+
+	if x == nil {
+		x = util.NewStringLit("nil")
+	}
 
 	body.List = append(body.List, &goast.IfStmt{
 		Cond: &goast.UnaryExpr{

--- a/transpiler/call.go
+++ b/transpiler/call.go
@@ -165,6 +165,10 @@ func transpileCallExpr(n *ast.CallExpr, p *program.Program) (
 				realArg, err = types.CastExpr(p, realArg, argTypes[i],
 					functionDef.ArgumentTypes[i])
 				ast.WarningOrError(err, n, realArg == nil)
+
+				if realArg == nil {
+					realArg = util.NewStringLit("nil")
+				}
 			}
 
 			realArgs = append(realArgs, realArg)

--- a/transpiler/declarations.go
+++ b/transpiler/declarations.go
@@ -16,8 +16,10 @@ import (
 )
 
 func transpileFieldDecl(p *program.Program, n *ast.FieldDecl) (*goast.Field, string) {
-	fieldType := types.ResolveType(p, n.Type)
 	name := n.Name
+
+	fieldType, err := types.ResolveType(p, n.Type)
+	ast.IsWarning(err, n)
 
 	// TODO: The name of a variable or field cannot be "type"
 	// https://github.com/elliotchance/c2go/issues/83
@@ -63,7 +65,7 @@ func transpileRecordDecl(p *program.Program, n *ast.RecordDecl) error {
 			fields = append(fields, f)
 		} else {
 			message := fmt.Sprintf("could not parse %v", c)
-			ast.Warning(errors.New(message), c)
+			ast.IsWarning(errors.New(message), c)
 		}
 	}
 
@@ -93,7 +95,8 @@ func transpileTypedefDecl(p *program.Program, n *ast.TypedefDecl) error {
 
 	p.TypeIsNowDefined(name)
 
-	resolvedType := types.ResolveType(p, n.Type)
+	resolvedType, err := types.ResolveType(p, n.Type)
+	ast.IsWarning(err, n)
 
 	// There is a case where the name of the type is also the definition,
 	// like:
@@ -158,7 +161,9 @@ func transpileTypedefDecl(p *program.Program, n *ast.TypedefDecl) error {
 
 func transpileVarDecl(p *program.Program, n *ast.VarDecl) (
 	[]goast.Stmt, []goast.Stmt, string) {
-	theType := types.ResolveType(p, n.Type)
+	theType, err := types.ResolveType(p, n.Type)
+	ast.IsWarning(err, n)
+
 	name := n.Name
 	preStmts := []goast.Stmt{}
 	postStmts := []goast.Stmt{}
@@ -226,8 +231,10 @@ func transpileVarDecl(p *program.Program, n *ast.VarDecl) (
 
 		preStmts, postStmts = combinePreAndPostStmts(preStmts, postStmts, newPre, newPost)
 
-		defaultValues = []goast.Expr{
-			types.CastExpr(p, defaultValue, defaultValueType, n.Type),
+		e, err := types.CastExpr(p, defaultValue, defaultValueType, n.Type)
+
+		if !ast.IsWarning(err, n) {
+			defaultValues = []goast.Expr{e}
 		}
 	}
 

--- a/transpiler/declarations.go
+++ b/transpiler/declarations.go
@@ -4,6 +4,8 @@
 package transpiler
 
 import (
+	"errors"
+	"fmt"
 	goast "go/ast"
 	"go/token"
 
@@ -56,8 +58,13 @@ func transpileRecordDecl(p *program.Program, n *ast.RecordDecl) error {
 
 	var fields []*goast.Field
 	for _, c := range n.Children {
-		f, _ := transpileFieldDecl(p, c.(*ast.FieldDecl))
-		fields = append(fields, f)
+		if field, ok := c.(*ast.FieldDecl); ok {
+			f, _ := transpileFieldDecl(p, field)
+			fields = append(fields, f)
+		} else {
+			message := fmt.Sprintf("could not parse %v", c)
+			ast.Warning(errors.New(message), c)
+		}
 	}
 
 	p.File.Decls = append(p.File.Decls, &goast.GenDecl{

--- a/transpiler/functions.go
+++ b/transpiler/functions.go
@@ -102,7 +102,8 @@ func transpileFunctionDecl(n *ast.FunctionDecl, p *program.Program) error {
 		// immediately to stdout. This will appear at the top of the program but
 		// make it much easier to diagnose when the transpiler errors.
 		if p.Verbose {
-			fmt.Printf("// Function: %s(%s)\n", f.Name, strings.Join(f.ArgumentTypes, ", "))
+			fmt.Printf("// Function: %s(%s)\n", f.Name,
+				strings.Join(f.ArgumentTypes, ", "))
 		}
 
 		fieldList, err := getFieldList(n, p)

--- a/transpiler/functions.go
+++ b/transpiler/functions.go
@@ -128,11 +128,9 @@ func transpileFunctionDecl(n *ast.FunctionDecl, p *program.Program) error {
 			// We also need to append a setup function that will instantiate
 			// some things that are expected to be available at runtime.
 			body.List = append([]goast.Stmt{
-				&goast.ExprStmt{
-					X: &goast.CallExpr{
-						Fun: goast.NewIdent("__init"),
-					},
-				},
+				util.NewExprStmt(&goast.CallExpr{
+					Fun: goast.NewIdent("__init"),
+				}),
 			}, body.List...)
 		}
 
@@ -203,12 +201,10 @@ func transpileReturnStmt(n *ast.ReturnStmt, p *program.Program) (
 		litExpr, isLiteral := e.(*goast.BasicLit)
 		if !isLiteral || (isLiteral && litExpr.Value != "0") {
 			p.AddImport("os")
-			return &goast.ExprStmt{
-				X: &goast.CallExpr{
-					Fun:  goast.NewIdent("os.Exit"),
-					Args: results,
-				},
-			}, preStmts, postStmts, nil
+			return util.NewExprStmt(&goast.CallExpr{
+				Fun:  goast.NewIdent("os.Exit"),
+				Args: results,
+			}), preStmts, postStmts, nil
 		}
 		results = []goast.Expr{}
 	}

--- a/transpiler/functions.go
+++ b/transpiler/functions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elliotchance/c2go/ast"
 	"github.com/elliotchance/c2go/program"
 	"github.com/elliotchance/c2go/types"
+	"github.com/elliotchance/c2go/util"
 
 	goast "go/ast"
 )
@@ -191,7 +192,9 @@ func transpileReturnStmt(n *ast.ReturnStmt, p *program.Program) (
 	f := program.GetFunctionDefinition(p.FunctionName)
 
 	t, err := types.CastExpr(p, e, eType, f.ReturnType)
-	ast.WarningOrError(err, n, t == nil)
+	if ast.IsWarning(err, n) {
+		t = util.NewStringLit("nil")
+	}
 
 	results := []goast.Expr{t}
 

--- a/transpiler/operators.go
+++ b/transpiler/operators.go
@@ -214,6 +214,8 @@ func getTokenForOperator(operator string) token.Token {
 		return token.SHR
 	case "<<":
 		return token.SHL
+	case "^":
+		return token.XOR
 
 	// Comparison
 	case ">=":
@@ -236,6 +238,10 @@ func getTokenForOperator(operator string) token.Token {
 		return token.LAND
 	case "||":
 		return token.LOR
+
+	// Other
+	case ",":
+		return token.COMMA
 	}
 
 	panic(fmt.Sprintf("unknown operator: %s", operator))

--- a/transpiler/switch.go
+++ b/transpiler/switch.go
@@ -50,6 +50,10 @@ func transpileSwitchStmt(n *ast.SwitchStmt, p *program.Program) (
 	// of goast.SwitchStmt.
 	stmts := []goast.Stmt{}
 	for _, singleCase := range cases {
+		if singleCase == nil {
+			panic("nil single case")
+		}
+
 		stmts = append(stmts, singleCase)
 	}
 
@@ -134,7 +138,9 @@ func normalizeSwitchCases(body *ast.CompoundStmt, p *program.Program) (
 				return []*goast.CaseClause{}, nil, nil, err
 			}
 
-			cases[len(cases)-1].Body = append(cases[len(cases)-1].Body, stmt)
+			if stmt != nil {
+				cases[len(cases)-1].Body = append(cases[len(cases)-1].Body, stmt)
+			}
 		}
 	}
 

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/elliotchance/c2go/ast"
 	"github.com/elliotchance/c2go/program"
+	"github.com/elliotchance/c2go/util"
 )
 
 func TranspileAST(fileName string, p *program.Program, root ast.Node) error {
@@ -127,6 +128,7 @@ func transpileToExpr(node ast.Node, p *program.Program) (
 
 	default:
 		ast.IsWarning(errors.New("cannot transpile to expr"), node)
+		expr = util.NewStringLit("nil")
 	}
 
 	// Real return is through named arguments.
@@ -209,9 +211,7 @@ func transpileToStmt(node ast.Node, p *program.Program) (
 		return
 	}
 
-	stmt = &goast.ExprStmt{
-		X: expr,
-	}
+	stmt = util.NewExprStmt(expr)
 
 	return
 }

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -3,6 +3,7 @@
 package transpiler
 
 import (
+	"errors"
 	"fmt"
 	goast "go/ast"
 	"go/parser"
@@ -125,7 +126,7 @@ func transpileToExpr(node ast.Node, p *program.Program) (
 		return transpileUnaryExprOrTypeTraitExpr(n, p)
 
 	default:
-		panic(fmt.Sprintf("cannot transpile to expr: %#v", node))
+		ast.IsWarning(errors.New("cannot transpile to expr"), node)
 	}
 
 	// Real return is through named arguments.

--- a/transpiler/unary.go
+++ b/transpiler/unary.go
@@ -134,6 +134,12 @@ func transpileUnaryExprOrTypeTraitExpr(n *ast.UnaryExprOrTypeTraitExpr, p *progr
 		case *ast.MemberExpr:
 			t = ty.Type
 
+		case *ast.UnaryOperator:
+			t = ty.Type
+
+		case *ast.ParenExpr:
+			t = ty.Type
+
 		default:
 			panic(fmt.Sprintf("cannot do unary on: %#v", ty))
 		}

--- a/transpiler/variables.go
+++ b/transpiler/variables.go
@@ -114,6 +114,9 @@ func transpileDeclStmt(n *ast.DeclStmt, p *program.Program) (
 
 			decls = append(decls, e)
 
+		case *ast.TypedefDecl:
+			ast.IsWarning(errors.New("cannot use TypedefDecl for DeclStmt"), c)
+
 		default:
 			panic(a)
 		}

--- a/types/cast.go
+++ b/types/cast.go
@@ -27,46 +27,53 @@ func GetArrayTypeAndSize(s string) (string, int) {
 	return "", -1
 }
 
-func CastExpr(p *program.Program, expr ast.Expr, fromType, toType string) ast.Expr {
+func CastExpr(p *program.Program, expr ast.Expr, fromType, toType string) (ast.Expr, error) {
 	// Let's assume that anything can be converted to a void pointer.
 	if toType == "void *" {
-		return expr
+		return expr, nil
 	}
 
-	fromType = ResolveType(p, fromType)
-	toType = ResolveType(p, toType)
+	fromType, err := ResolveType(p, fromType)
+	if err != nil {
+		return expr, err
+	}
+
+	toType, err = ResolveType(p, toType)
+	if err != nil {
+		return expr, err
+	}
 
 	// FIXME: This is a hack to avoid casting in some situations.
 	if fromType == "" || toType == "" {
-		return expr
+		return expr, nil
 	}
 
 	if fromType == "[]byte" && toType == "string" {
 		p.AddImport("github.com/elliotchance/c2go/noarch")
-		return util.NewCallExpr("noarch.NullTerminatedByteSlice", expr)
+		return util.NewCallExpr("noarch.NullTerminatedByteSlice", expr), nil
 	}
 
 	if fromType == "null" && toType == "string" {
 		return &goast.BasicLit{
 			Kind:  token.STRING,
 			Value: `""`,
-		}
+		}, nil
 	}
 
 	if fromType == "null" && toType == "*string" {
 		return &goast.BasicLit{
 			Kind:  token.STRING,
 			Value: `""`,
-		}
+		}, nil
 	}
 
 	// This if for linux.
 	if fromType == "*_IO_FILE" && toType == "*noarch.File" {
-		return expr
+		return expr, nil
 	}
 
 	if fromType == toType {
-		return expr
+		return expr, nil
 	}
 
 	// Compatible integer types
@@ -94,7 +101,7 @@ func CastExpr(p *program.Program, expr ast.Expr, fromType, toType string) ast.Ex
 					Kind:  token.STRING,
 					Value: "0",
 				},
-			}
+			}, nil
 		}
 	}
 
@@ -132,7 +139,7 @@ func CastExpr(p *program.Program, expr ast.Expr, fromType, toType string) ast.Ex
 			Value: "0",
 		})
 
-		return value
+		return value, nil
 	}
 
 	// In the forms of:
@@ -163,7 +170,7 @@ func CastExpr(p *program.Program, expr ast.Expr, fromType, toType string) ast.Ex
 					},
 				},
 			},
-		}
+		}, nil
 	}
 
 	// Anything that is a pointer can be compared to nil
@@ -175,31 +182,31 @@ func CastExpr(p *program.Program, expr ast.Expr, fromType, toType string) ast.Ex
 				Kind:  token.STRING,
 				Value: "nil",
 			},
-		}
+		}, nil
 	}
 
 	if fromType == "int" && toType == "*int" {
 		return &goast.BasicLit{
 			Kind:  token.STRING,
 			Value: "nil",
-		}
+		}, nil
 	}
 	if fromType == "int" && toType == "*byte" {
 		return &goast.BasicLit{
 			Kind:  token.STRING,
 			Value: `""`,
-		}
+		}, nil
 	}
 
 	if fromType == "_Bool" && toType == "bool" {
-		return expr
+		return expr, nil
 	}
 
 	if util.InStrings(fromType, types) && util.InStrings(toType, types) {
 		return &goast.CallExpr{
 			Fun:  goast.NewIdent(toType),
 			Args: []goast.Expr{expr},
-		}
+		}, nil
 	}
 
 	p.AddImport("github.com/elliotchance/c2go/noarch")
@@ -222,7 +229,7 @@ func CastExpr(p *program.Program, expr ast.Expr, fromType, toType string) ast.Ex
 	return &goast.CallExpr{
 		Fun:  goast.NewIdent(functionName),
 		Args: []goast.Expr{expr},
-	}
+	}, nil
 }
 
 func IsNullExpr(n goast.Expr) bool {

--- a/types/resolve.go
+++ b/types/resolve.go
@@ -198,5 +198,7 @@ func ResolveType(p *program.Program, s string) (string, error) {
 		return fmt.Sprintf("[]%s", t), err
 	}
 
-	panic(fmt.Sprintf("I couldn't find an appropriate Go type for the C type '%s'.", s))
+	errMsg := fmt.Sprintf(
+		"I couldn't find an appropriate Go type for the C type '%s'.", s)
+	return "interface{}", errors.New(errMsg)
 }

--- a/types/resolve.go
+++ b/types/resolve.go
@@ -54,7 +54,6 @@ var simpleResolveTypes = map[string]string{
 
 	// Darwin specific
 	"__darwin_ct_rune_t": "github.com/elliotchance/c2go/darwin.Darwin_ct_rune_t",
-	"union __mbstate_t":  "__mbstate_t",
 	"fpos_t":             "int",
 	"struct __float2":    "github.com/elliotchance/c2go/darwin.Float2",
 	"struct __double2":   "github.com/elliotchance/c2go/darwin.Double2",
@@ -73,20 +72,6 @@ var simpleResolveTypes = map[string]string{
 	"__sFILEX":                     "interface{}",
 	"__va_list_tag":                "interface{}",
 	"FILE":                         "github.com/elliotchance/c2go/noarch.File",
-	"union sigval":                 "int",
-	"union __sigaction_u":          "int",
-
-	// Linux specific
-	"union __WAIT_STATUS":         "interface{}",
-	"union pthread_mutex_t":       "interface{}",
-	"union pthread_mutexattr_t":   "interface{}",
-	"union pthread_cond_t":        "interface{}",
-	"union pthread_condattr_t":    "interface{}",
-	"union pthread_rwlock_t":      "interface{}",
-	"union pthread_rwlockattr_t":  "interface{}",
-	"union pthread_barrier_t":     "interface{}",
-	"union pthread_barrierattr_t": "interface{}",
-	"union pthread_attr_t":        "interface{}",
 }
 
 func ResolveType(p *program.Program, s string) string {
@@ -96,6 +81,15 @@ func ResolveType(p *program.Program, s string) string {
 	s = strings.Replace(s, "*__restrict", "*", -1)
 	s = strings.Replace(s, "*restrict", "*", -1)
 	s = strings.Trim(s, " \t\n\r")
+
+	// TODO: Unions are not supported.
+	// https://github.com/elliotchance/c2go/issues/84
+	//
+	// For now we will let them be interface{} so that it does not stop the
+	// transpilation.
+	if strings.HasPrefix(s, "union ") {
+		return "interface{}"
+	}
 
 	// FIXME: This is a hack to avoid casting in some situations.
 	if s == "" {

--- a/types/sizeof.go
+++ b/types/sizeof.go
@@ -33,7 +33,12 @@ func SizeOf(p *program.Program, cType string) (int, error) {
 	if strings.HasPrefix(cType, "struct ") {
 		totalBytes := 0
 
-		for _, t := range p.Structs[cType[7:]].Fields {
+		s := p.Structs[cType[7:]]
+		if s == nil {
+			return 0, errors.New(fmt.Sprintf("could not sizeof: %s", cType))
+		}
+
+		for _, t := range s.Fields {
 			var bytes int
 			var err error
 

--- a/util/goast.go
+++ b/util/goast.go
@@ -9,6 +9,16 @@ import (
 	"strconv"
 )
 
+func NewExprStmt(expr goast.Expr) *goast.ExprStmt {
+	if expr == nil {
+		panic("expr is nil")
+	}
+
+	return &goast.ExprStmt{
+		X: expr,
+	}
+}
+
 func NewCallExpr(functionName string, args ...goast.Expr) *goast.CallExpr {
 	return &goast.CallExpr{
 		Fun:  goast.NewIdent(functionName),
@@ -17,6 +27,13 @@ func NewCallExpr(functionName string, args ...goast.Expr) *goast.CallExpr {
 }
 
 func NewBinaryExpr(left goast.Expr, operator token.Token, right goast.Expr) *goast.BinaryExpr {
+	if left == nil {
+		panic("left is nil")
+	}
+	if right == nil {
+		panic("right is nil")
+	}
+
 	return &goast.BinaryExpr{
 		X:  left,
 		Op: operator,


### PR DESCRIPTION
Up until this point most errors result in a panic. This is useful when early stages debugging but it would be extremely painful for anyone trying to properly use the tool if every tiny infringements caused the whole process to stop.

This PR will print errors and warnings as comments at the top of the file, but try to continue sensibly so that it will produce the best Go it can even if that turns out to be not completely correct.

I am testing this on the whole amalgamated SQLite3 source code. Obviously c2go is not at all mature enough to transpire this. However, if i can get it to spit out lots of warnings and at least produce some Go it will be a major step in the right direction.

I have a feeling this PR will turn out to have a great lot of changes so it's likely it will have around for a while, then get it's own release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/112)
<!-- Reviewable:end -->
