### PR TITLE
Implement parenthesized import declaration

### DIFF
--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -48,14 +48,14 @@ func TranspileAST(fileName string, p *program.Program, root ast.Node) error {
 	// declaration. According to the function definition, line should be
 	// greater than 0.
 	importDecl := &goast.GenDecl{
-		Tok: token.IMPORT,
+		Tok:    token.IMPORT,
 		Lparen: 1,
 	}
 
 	for _, quotedImportPath := range p.Imports() {
 		importSpec := &goast.ImportSpec{
 			Path: &goast.BasicLit{
-				Kind: token.IMPORT,
+				Kind:  token.IMPORT,
 				Value: quotedImportPath,
 			},
 		}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -44,20 +44,26 @@ func TranspileAST(fileName string, p *program.Program, root ast.Node) error {
 
 	// Add the imports after everything else so we can ensure that they are all
 	// placed at the top.
+	// A valid Lparen position (Lparen.IsValid()) indicated a parenthesized
+	// declaration. According to the function definition, line should be
+	// greater than 0.
+	importDecl := &goast.GenDecl{
+		Tok: token.IMPORT,
+		Lparen: 1,
+	}
+
 	for _, quotedImportPath := range p.Imports() {
 		importSpec := &goast.ImportSpec{
 			Path: &goast.BasicLit{
-				Kind:  token.IMPORT,
+				Kind: token.IMPORT,
 				Value: quotedImportPath,
 			},
 		}
-		importDecl := &goast.GenDecl{
-			Tok: token.IMPORT,
-		}
 
 		importDecl.Specs = append(importDecl.Specs, importSpec)
-		p.File.Decls = append([]goast.Decl{importDecl}, p.File.Decls...)
 	}
+
+	p.File.Decls = append([]goast.Decl{importDecl}, p.File.Decls...)
 
 	return err
 }


### PR DESCRIPTION
[https://golang.org/pkg/go/ast/#GenDecl](https://golang.org/pkg/go/ast/#GenDecl)
According to the 'GenDecl' type definition, a generic declaration like
import, constant, type or variable declaration, it will result in a
parenthesized declaration if the 'Lparen' position is valid.

[https://golang.org/pkg/go/token/#Position](https://golang.org/pkg/go/token/#Position)
A token position is valid if the line number is greater than 0.

Fixes #119.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/131)
<!-- Reviewable:end -->
