### PR TITLE
Add flag to set the generated package name

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,10 +28,11 @@ import (
 const Version = "0.12.1"
 
 type ProgramArgs struct {
-	verbose    bool
-	ast        bool
-	inputFile  string
-	outputFile string
+	verbose     bool
+	ast         bool
+	inputFile   string
+	outputFile  string
+	packageName string
 }
 
 func readAST(data []byte) []string {
@@ -182,7 +183,7 @@ func Start(args ProgramArgs) {
 	p := program.NewProgram()
 	p.Verbose = args.verbose
 
-	err = transpiler.TranspileAST(args.inputFile, p, tree[0].(ast.Node))
+	err = transpiler.TranspileAST(args.inputFile, args.packageName, p, tree[0].(ast.Node))
 	if err != nil {
 		panic(err)
 	}
@@ -211,6 +212,7 @@ func main() {
 		transpileCommand = flag.NewFlagSet("transpile", flag.ContinueOnError)
 		verboseFlag      = transpileCommand.Bool("V", false, "print progress as comments")
 		outputFlag       = transpileCommand.String("o", "", "output Go generated code to the specified file")
+		packageFlag      = transpileCommand.String("p", "main", "set the name of the generated package")
 		astCommand       = flag.NewFlagSet("ast", flag.ContinueOnError)
 	)
 
@@ -258,13 +260,14 @@ func main() {
 		transpileCommand.Parse(os.Args[2:])
 
 		if transpileCommand.NArg() == 0 {
-			fmt.Fprintf(os.Stderr, "Usage: %s transpile [-V] [-o file.go] file.c\n", os.Args[0])
+			fmt.Fprintf(os.Stderr, "Usage: %s transpile [-V] [-o file.go] [-p package] file.c\n", os.Args[0])
 			transpileCommand.PrintDefaults()
 			os.Exit(1)
 		}
 
 		args.inputFile = transpileCommand.Arg(0)
 		args.outputFile = *outputFlag
+		args.packageName = *packageFlag
 
 		Start(args)
 	default:

--- a/main_test.go
+++ b/main_test.go
@@ -66,7 +66,11 @@ func TestIntegrationScripts(t *testing.T) {
 			err = cmd.Run()
 			cProgram.isZero = err == nil
 
-			programArgs := ProgramArgs{inputFile: file, outputFile: "build/main.go", packageName: "main"}
+			programArgs := ProgramArgs{
+				inputFile:   file,
+				outputFile:  "build/main.go",
+				packageName: "main",
+			}
 
 			// Compile Go
 			Start(programArgs)

--- a/main_test.go
+++ b/main_test.go
@@ -66,7 +66,7 @@ func TestIntegrationScripts(t *testing.T) {
 			err = cmd.Run()
 			cProgram.isZero = err == nil
 
-			programArgs := ProgramArgs{inputFile: file, outputFile: "build/main.go"}
+			programArgs := ProgramArgs{inputFile: file, outputFile: "build/main.go", packageName: "main"}
 
 			// Compile Go
 			Start(programArgs)

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -17,7 +17,8 @@ import (
 func TranspileAST(fileName, packageName string, p *program.Program, root ast.Node) error {
 	// Start by parsing an empty file.
 	p.FileSet = token.NewFileSet()
-	f, err := parser.ParseFile(p.FileSet, fileName, fmt.Sprintf("package %v", packageName), 0)
+	packageSignature := fmt.Sprintf("package %v", packageName)
+	f, err := parser.ParseFile(p.FileSet, fileName, packageSignature, 0)
 	p.File = f
 
 	if err != nil {

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -14,10 +14,10 @@ import (
 	"github.com/elliotchance/c2go/util"
 )
 
-func TranspileAST(fileName string, p *program.Program, root ast.Node) error {
+func TranspileAST(fileName, packageName string, p *program.Program, root ast.Node) error {
 	// Start by parsing an empty file.
 	p.FileSet = token.NewFileSet()
-	f, err := parser.ParseFile(p.FileSet, fileName, "package main", 0)
+	f, err := parser.ParseFile(p.FileSet, fileName, fmt.Sprintf("package %v", packageName), 0)
 	p.File = f
 
 	if err != nil {

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elliotchance/c2go/util"
 )
 
+// TranspileAST iterates through the Clang AST and builds a Go AST
 func TranspileAST(fileName, packageName string, p *program.Program, root ast.Node) error {
 	// Start by parsing an empty file.
 	p.FileSet = token.NewFileSet()


### PR DESCRIPTION
Implement the 'packageFlag' (type string) flag to 'transpile' command.
Its default value is 'main'.

Fixes #125.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/135)
<!-- Reviewable:end -->
