### PR TITLE
Allow conversions to and from int8 and uint8

### DIFF
--- a/tests/operators.c
+++ b/tests/operators.c
@@ -8,7 +8,8 @@ int main()
 {
 	plan(19);
 
-    int i = 10, j = 1;
+    int i = 10;
+    signed char j = 1;
     float f = 3.14159f;
     double d = 0.0;
     char c = 'A';

--- a/types/cast.go
+++ b/types/cast.go
@@ -77,8 +77,8 @@ func CastExpr(p *program.Program, expr ast.Expr, fromType, toType string) (ast.E
 	types := []string{
 		// Integer types
 		"byte",
-		"int", "int16", "int32", "int64",
-		"uint16", "uint32", "uint64",
+		"int", "int8", "int16", "int32", "int64",
+		"uint8", "uint16", "uint32", "uint64",
 
 		// Floating-point types.
 		"float32", "float64",


### PR DESCRIPTION
Looks like `int8` and `uint8` got missed in the types that can be converted to `bool` and each other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/164)
<!-- Reviewable:end -->
