### PR TITLE
Fix for operator FOR without body

### DIFF
--- a/tests/for.c
+++ b/tests/for.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-    plan(31);
+    plan(32);
 
     int i = 0;
 
@@ -71,6 +71,10 @@ int main()
 		pass("%d %d", i, j);
 		j++;
 	}
+
+	diag("Without body and with 2 and more increments");
+	for(i = 0, j = 0; i < 2; j++,i++);
+	pass("%d",i)
 
     done_testing();
 }

--- a/tests/for.c
+++ b/tests/for.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-    plan(32);
+    plan(33);
 
     int i = 0;
 
@@ -74,6 +74,10 @@ int main()
 
 	diag("Without body and with 2 and more increments");
 	for(i = 0, j = 0; i < 2; j++,i++);
+	pass("%d",i)
+
+	diag("Without body and with 2 and more conditions");
+	for(i = 0, j = 0; j++,i++,i < 2; );
 	pass("%d",i)
 
     done_testing();

--- a/transpiler/branch.go
+++ b/transpiler/branch.go
@@ -173,13 +173,16 @@ func transpileForStmt(n *ast.ForStmt, p *program.Program) (
 			//		c+=2;
 			// }
 			//
-			var compound ast.CompoundStmt
-			// if body is exist
+			var compound *ast.CompoundStmt
 			if children[4] != nil {
-				compound = *children[4].(*ast.CompoundStmt)
+				// if body is exist
+				compound = children[4].(*ast.CompoundStmt)
+			} else {
+				// if body is not exist
+				compound = new(ast.CompoundStmt)
 			}
 			compound.Children = append(compound.Children, c.Children[0:len(c.Children)]...)
-			children[4] = &compound
+			children[4] = compound
 			children[3] = nil
 		}
 	}
@@ -224,14 +227,16 @@ func transpileForStmt(n *ast.ForStmt, p *program.Program) (
 
 			tempSlice = append(tempSlice, &condition)
 
-			var compound ast.CompoundStmt
-			// if body is exist
+			var compound *ast.CompoundStmt
 			if children[4] != nil {
-				compound = *children[4].(*ast.CompoundStmt)
+				// if body is exist
+				compound = children[4].(*ast.CompoundStmt)
+			} else {
+				// if body is not exist
+				compound = new(ast.CompoundStmt)
 			}
 			compound.Children = append(tempSlice, compound.Children...)
-			children[4] = &compound
-
+			children[4] = compound
 			children[2] = nil
 		}
 	}

--- a/transpiler/branch.go
+++ b/transpiler/branch.go
@@ -224,9 +224,13 @@ func transpileForStmt(n *ast.ForStmt, p *program.Program) (
 
 			tempSlice = append(tempSlice, &condition)
 
-			compound := children[4].(*ast.CompoundStmt)
+			var compound ast.CompoundStmt
+			// if body is exist
+			if children[4] != nil {
+				compound = *children[4].(*ast.CompoundStmt)
+			}
 			compound.Children = append(tempSlice, compound.Children...)
-			children[4] = compound
+			children[4] = &compound
 
 			children[2] = nil
 		}

--- a/transpiler/branch.go
+++ b/transpiler/branch.go
@@ -174,6 +174,7 @@ func transpileForStmt(n *ast.ForStmt, p *program.Program) (
 			// }
 			//
 			var compound ast.CompoundStmt
+			// if body is exist
 			if children[4] != nil {
 				compound = *children[4].(*ast.CompoundStmt)
 			}

--- a/transpiler/branch.go
+++ b/transpiler/branch.go
@@ -173,9 +173,12 @@ func transpileForStmt(n *ast.ForStmt, p *program.Program) (
 			//		c+=2;
 			// }
 			//
-			compound := children[4].(*ast.CompoundStmt)
+			var compound ast.CompoundStmt
+			if children[4] != nil {
+				compound = *children[4].(*ast.CompoundStmt)
+			}
 			compound.Children = append(compound.Children, c.Children[0:len(c.Children)]...)
-			children[4] = compound
+			children[4] = &compound
 			children[3] = nil
 		}
 	}


### PR DESCRIPTION
Fix for operator FOR without body.
Example of C code:
```c
for(p=1, lcv=2; lcv <= n; p=p*lcv, lcv++);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/186)
<!-- Reviewable:end -->
