### PR TITLE
Change to use strings.TrimLeft instead of regexp

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,16 +55,9 @@ func convertLinesToNodes(lines []string) []treeNode {
 		// have semantic importance: for example, they represent omitted
 		// for-loop conditions, as in for(;;).
 		line = strings.Replace(line, "<<<NULL>>>", "NullStmt", 1)
-
-		indentAndType := regexp.MustCompile("^([|\\- `]*)(\\w+)").FindStringSubmatch(line)
-		if len(indentAndType) == 0 {
-			panic(fmt.Sprintf("Cannot understand line '%s'", line))
-		}
-
-		offset := len(indentAndType[1])
-		node := ast.Parse(line[offset:])
-
-		indentLevel := len(indentAndType[1]) / 2
+		trimmed := strings.TrimLeft(line, "|\\- `")
+		node := ast.Parse(trimmed)
+		indentLevel := (len(line) - len(trimmed)) / 2
 		nodes = append(nodes, treeNode{indentLevel, node})
 	}
 


### PR DESCRIPTION
Was fooling around with parsing libxml2, and got this output

```
|-TypedefDecl 0x7fd88090c5d8 <line:845:1, line:847:9> line:845:17 referenced xmlGenericErrorFunc 'void (*)(void *, const char *, ...)'
| |-PointerType 0x7fd88090c570 'void (*)(void *, const char *, ...)'
| | `-ParenType 0x7fd88090c510 'void (void *, const char *, ...)' sugar
| |   `-FunctionProtoType 0x7fd88090c4d0 'void (void *, const char *,
...)' cdecl
| |     |-BuiltinType 0x7fd88081c520 'void'
| |     |-PointerType 0x7fd88081c950 'void *'
| |     | `-BuiltinType 0x7fd88081c520 'void'
| |     |-PointerType 0x7fd88081cb90 'const char *'
| |     | `-QualType 0x7fd88081c561 'const char' const
| |     |   `-BuiltinType 0x7fd88081c560 'char'
| |     `-...
```

And c2go choked on the last line, saying

```
  panic: Cannot understand line '| |     `-...'
```

In this case the prefix matches, but the dots don't match against \w, so
this line fails.

Anyway, using regular expression with this particular pattern seems
overkill, so it has been changed to strings.TrimLeft

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/197)
<!-- Reviewable:end -->
