### PR TITLE
#184: panic: could not match regexp

### DIFF
--- a/ast/deprecated_attr.go
+++ b/ast/deprecated_attr.go
@@ -10,7 +10,7 @@ type DeprecatedAttr struct {
 
 func parseDeprecatedAttr(line string) *DeprecatedAttr {
 	groups := groupsFromRegex(
-		`<(?P<position>.*)> "(?P<message1>.*?)"(?P<message2> ".*?")?`,
+		`<(?P<position>.*)> (.*)"(?P<message1>.*?)"(?P<message2> ".*?")?`,
 		line,
 	)
 


### PR DESCRIPTION
The issue related to wrong parsing by regex:
'(?P<address>[0-9a-fx]+) <(?P<position>.*)> "(?P<message1>.*?)"(?P<message2> ".*?")?'

wrong message, it's reason of panic:
'DeprecatedAttr 0xb75d00 <line:1107:12> Inherited "This function or variable may be unsafe. Consider using _snwprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details." ""'

should be for correct message parsing:
'DeprecatedAttr 0xb75d00 <line:1107:12> "This function or variable may be unsafe. Consider using _snwprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details." ""'

Conclusion: message 'Inherited' which did not processed by regexp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/205)
<!-- Reviewable:end -->
