### PR TITLE
Make snapshots more readable and diffable

### DIFF
--- a/.snapshots/c2go-TestCLI-func1-AstHelpFlag
+++ b/.snapshots/c2go-TestCLI-func1-AstHelpFlag
@@ -1,1 +1,5 @@
-(string) (len=51) "Usage: test ast file.c\n  -h\tprint help information\n"
+([]string) (len=3) {
+  (string) (len=22) "Usage: test ast file.c",
+  (string) (len=27) "  -h\tprint help information",
+  (string) ""
+}

--- a/.snapshots/c2go-TestCLI-func1-AstNoFilesHelp
+++ b/.snapshots/c2go-TestCLI-func1-AstNoFilesHelp
@@ -1,1 +1,5 @@
-(string) (len=51) "Usage: test ast file.c\n  -h\tprint help information\n"
+([]string) (len=3) {
+  (string) (len=22) "Usage: test ast file.c",
+  (string) (len=27) "  -h\tprint help information",
+  (string) ""
+}

--- a/.snapshots/c2go-TestCLI-func1-TranspileHelpFlag
+++ b/.snapshots/c2go-TestCLI-func1-TranspileHelpFlag
@@ -1,1 +1,10 @@
-(string) (len=256) "Usage: test transpile [-V] [-o file.go] [-p package] file.c\n  -V\tprint progress as comments\n  -h\tprint help information\n  -o string\n    \toutput Go generated code to the specified file\n  -p string\n    \tset the name of the generated package (default \"main\")\n"
+([]string) (len=8) {
+  (string) (len=59) "Usage: test transpile [-V] [-o file.go] [-p package] file.c",
+  (string) (len=31) "  -V\tprint progress as comments",
+  (string) (len=27) "  -h\tprint help information",
+  (string) (len=11) "  -o string",
+  (string) (len=51) "    \toutput Go generated code to the specified file",
+  (string) (len=11) "  -p string",
+  (string) (len=59) "    \tset the name of the generated package (default \"main\")",
+  (string) ""
+}

--- a/.snapshots/c2go-TestCLI-func1-TranspileNoFilesHelp
+++ b/.snapshots/c2go-TestCLI-func1-TranspileNoFilesHelp
@@ -1,1 +1,10 @@
-(string) (len=256) "Usage: test transpile [-V] [-o file.go] [-p package] file.c\n  -V\tprint progress as comments\n  -h\tprint help information\n  -o string\n    \toutput Go generated code to the specified file\n  -p string\n    \tset the name of the generated package (default \"main\")\n"
+([]string) (len=8) {
+  (string) (len=59) "Usage: test transpile [-V] [-o file.go] [-p package] file.c",
+  (string) (len=31) "  -V\tprint progress as comments",
+  (string) (len=27) "  -h\tprint help information",
+  (string) (len=11) "  -o string",
+  (string) (len=51) "    \toutput Go generated code to the specified file",
+  (string) (len=11) "  -p string",
+  (string) (len=59) "    \tset the name of the generated package (default \"main\")",
+  (string) ""
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"github.com/bradleyjkemp/cupaloy"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -42,7 +43,8 @@ func TestCLI(t *testing.T) {
 			defer teardown()
 
 			runCommand()
-			err := cupaloy.SnapshotMulti(testName, output.String())
+			outputLines := strings.Split(output.String(), "\n")
+			err := cupaloy.SnapshotMulti(testName, outputLines)
 			if err != nil {
 				t.Fatalf("error: %s", err)
 			}


### PR DESCRIPTION
I realised that splitting the output into lines before snapshotting makes the output much more readable when diffing changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/212)
<!-- Reviewable:end -->
