### PR TITLE
Add feature for unused type

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -260,7 +260,7 @@ func TestStartPreprocess(t *testing.T) {
 	// temp dir
 	tempDir := os.TempDir()
 
-	// create temp file with garantee
+	// create temp file with guarantee
 	// wrong file body
 	tempFile, err := newTempFile(tempDir, "c2go", "preprocess.c")
 	if err != nil {


### PR DESCRIPTION
Created for #232

Now, added cleaning by unused type.
Question:
* We don't use `vendor`ing. For that feature added 2 library "honnef.co/go/tools/...", but we don't have a vendor instrument like [golang/dep](https://github.com/golang/dep)
* Not clear - How to change snapshots for command line flags
* Have fail test on my laptop:
```
# github.com/elliotchance/c2go/build/tests/stdlib
build/tests/stdlib/main_test.go:36: undefined: pthread_attr_t
build/tests/stdlib/main_test.go:39: undefined: pthread_attr_t
build/tests/stdlib/main_test.go:44: undefined: pthread_attr_t
...
```
For future - we can add removing unused function, constants, variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/234)
<!-- Reviewable:end -->
