### PR TITLE
Remove executable bit for output file

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func Start(args ProgramArgs) error {
 		outputFilePath = cleanFileName[0:len(cleanFileName)-len(extension)] + ".go"
 	}
 
-	err = ioutil.WriteFile(outputFilePath, []byte(p.String()), 0755)
+	err = ioutil.WriteFile(outputFilePath, []byte(p.String()), 0644)
 	if err != nil {
 		return fmt.Errorf("writing C output file failed: %v", err)
 	}


### PR DESCRIPTION
The output Go file is not executable, so I think the executable bit should be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/245)
<!-- Reviewable:end -->
