### PR TITLE
Improved strictness and speed of regexp matching #312

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -41,7 +41,13 @@ func Parse(line string) Node {
 		return parseArrayFiller(line)
 	}
 
-	nodeName := strings.SplitN(line, " ", 2)[0]
+	parts := strings.SplitN(line, " ", 2)
+	nodeName := parts[0]
+
+	// skip node name
+	if len(parts) > 1 {
+		line = parts[1]
+	}
 
 	switch nodeName {
 	case "AlignedAttr":
@@ -227,7 +233,7 @@ func groupsFromRegex(rx, line string) map[string]string {
 	// We remove tabs and newlines from the regex. This is purely cosmetic,
 	// as the regex input can be quite long and it's nice for the caller to
 	// be able to format it in a more readable way.
-	fullRegexp := "(?P<address>[0-9a-fx]+) " +
+	fullRegexp := "^(?P<address>[0-9a-fx]+) " +
 		strings.Replace(strings.Replace(rx, "\n", "", -1), "\t", "", -1)
 	rx = fullRegexp
 
@@ -235,8 +241,7 @@ func groupsFromRegex(rx, line string) map[string]string {
 
 	match := re.FindStringSubmatch(line)
 	if len(match) == 0 {
-		panic("could not match regexp '" + rx +
-			"' with string '" + line + "'")
+		panic("could not match regexp with string\n" + rx + "\n" + line + "\n")
 	}
 
 	result := make(map[string]string)

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -56,3 +56,15 @@ func TestPrint(t *testing.T) {
 		t.Error("Not correct design of output")
 	}
 }
+
+var lines = []string{
+// c2go ast sqlite3.c | head -5000 | sed 's/^[ |`-]*//' | sed 's/<<<NULL>>>/NullStmt/g' | gawk 'length > 0 {print "`" $0 "`,"}'
+}
+
+func BenchmarkParse(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		for _, line := range lines {
+			Parse(line)
+		}
+	}
+}

--- a/ast/function_decl.go
+++ b/ast/function_decl.go
@@ -20,7 +20,7 @@ type FunctionDecl struct {
 
 func parseFunctionDecl(line string) *FunctionDecl {
 	groups := groupsFromRegex(
-		`(?P<prev>prev [0-9a-fx]+ )?
+		`(?:prev (?P<prev>0x[0-9a-f]+) )?
 		<(?P<position1>.*?)>
 		(?P<position2> <scratch space>[^ ]+| [^ ]+)?
 		(?P<implicit> implicit)?
@@ -32,15 +32,10 @@ func parseFunctionDecl(line string) *FunctionDecl {
 		line,
 	)
 
-	prev := groups["prev"]
-	if prev != "" {
-		prev = prev[5 : len(prev)-1]
-	}
-
 	return &FunctionDecl{
 		Addr:         ParseAddress(groups["address"]),
 		Pos:          NewPositionFromString(groups["position1"]),
-		Prev:         prev,
+		Prev:         groups["prev"],
 		Position2:    strings.TrimSpace(groups["position2"]),
 		Name:         groups["name"],
 		Type:         groups["type"],

--- a/ast/implicit_cast_expr_test.go
+++ b/ast/implicit_cast_expr_test.go
@@ -20,7 +20,7 @@ func TestImplicitCastExpr(t *testing.T) {
 			Kind:       "FunctionToPointerDecay",
 			ChildNodes: []Node{},
 		},
-		`ImplicitCastExpr 0x21267c8 <col:8> 'enum week1':'enum week2' <IntegralCast>`: &ImplicitCastExpr{
+		`0x21267c8 <col:8> 'enum week1':'enum week2' <IntegralCast>`: &ImplicitCastExpr{
 			Addr:       0x21267c8,
 			Pos:        NewPositionFromString("col:8"),
 			Type:       "enum week1",

--- a/ast/parm_var_decl_test.go
+++ b/ast/parm_var_decl_test.go
@@ -83,7 +83,7 @@ func TestParmVarDecl(t *testing.T) {
 			IsReferenced: false,
 			ChildNodes:   []Node{},
 		},
-		`ParmVarDecl 0x1d82850 <col:11, col:22> col:16 referenced foo 'char *':'char *'`: &ParmVarDecl{
+		`0x1d82850 <col:11, col:22> col:16 referenced foo 'char *':'char *'`: &ParmVarDecl{
 			Addr:         0x1d82850,
 			Pos:          NewPositionFromString("col:11, col:22"),
 			Position2:    "col:16",

--- a/ast/record_decl.go
+++ b/ast/record_decl.go
@@ -17,9 +17,10 @@ type RecordDecl struct {
 
 func parseRecordDecl(line string) *RecordDecl {
 	groups := groupsFromRegex(
-		`(?P<prev>prev 0x[0-9a-f]+ )?
+		`(?:parent (?P<parent>0x[0-9a-f]+) )?
+		(?:prev (?P<prev>0x[0-9a-f]+) )?
 		<(?P<position>.*)>
-		 (?P<position2>[^ ]+ )?
+		[ ](?P<position2>[^ ]+ )?
 		(?P<kind>struct|union)
 		(?P<name>.*)`,
 		line,

--- a/ast/record_decl_test.go
+++ b/ast/record_decl_test.go
@@ -36,6 +36,26 @@ func TestRecordDecl(t *testing.T) {
 			Definition: false,
 			ChildNodes: []Node{},
 		},
+		`0x5564ed488a10 parent 0x5564ed3ffe00 <line:7232:3, line:7237:3> line:7232:10 struct sqlite3_index_constraint definition`: &RecordDecl{
+			Addr:       0x5564ed488a10,
+			Pos:        NewPositionFromString("line:7232:3, line:7237:3"),
+			Prev:       "",
+			Position2:  "line:7232:10",
+			Kind:       "struct",
+			Name:       "sqlite3_index_constraint",
+			Definition: true,
+			ChildNodes: []Node{},
+		},
+		`0x56454e55e4b8 prev 0x56454e55e360 <line:86428:1, line:86437:1> line:86428:8 struct Incrblob definition`: &RecordDecl{
+			Addr:       0x56454e55e4b8,
+			Pos:        NewPositionFromString("line:86428:1, line:86437:1"),
+			Prev:       "0x56454e55e360",
+			Position2:  "line:86428:8",
+			Kind:       "struct",
+			Name:       "Incrblob",
+			Definition: true,
+			ChildNodes: []Node{},
+		},
 	}
 
 	runNodeTests(t, nodes)

--- a/ast/typedef_decl.go
+++ b/ast/typedef_decl.go
@@ -18,7 +18,8 @@ type TypedefDecl struct {
 
 func parseTypedefDecl(line string) *TypedefDecl {
 	groups := groupsFromRegex(
-		`<(?P<position><invalid sloc>|.*?)>
+		`(?:prev (?P<prev>0x[0-9a-f]+) )?
+		<(?P<position><invalid sloc>|.*?)>
 		(?P<position2> <invalid sloc>| col:\d+| line:\d+:\d+)?
 		(?P<implicit> implicit)?
 		(?P<referenced> referenced)?

--- a/ast/var_decl.go
+++ b/ast/var_decl.go
@@ -20,7 +20,8 @@ type VarDecl struct {
 
 func parseVarDecl(line string) *VarDecl {
 	groups := groupsFromRegex(
-		`<(?P<position>.*)>(?P<position2> .+:\d+)?
+		`(?:prev (?P<prev>0x[0-9a-f]+) )?
+		<(?P<position>.*)>(?P<position2> .+:\d+)?
 		(?P<used> used)?
 		(?P<referenced> referenced)?
 		(?P<name> \w+)?


### PR DESCRIPTION
For #312

The regexps are now stricter, i.e. need to match the whole line.

There is a minimal speed improvement by skipping the NodeName.

```
$ go test -run=NONE -bench=. -benchtime=10s > old
[change code]
$ go test -run=NONE -bench=. -benchtime=10s > new

$ go install golang.org/x/tools/cmd/benchcmp
$ benchcmp old new
benchmark          old ns/op     new ns/op     delta
BenchmarkParse     27993406      25026323      -10.60%
```

@elliotchance Is it possible to leave the issue open after this merge? I would like to make more changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/339)
<!-- Reviewable:end -->
