### PR TITLE
Fix preStmts and postStmts are not used in transpiler/branch. Fixes #404

### DIFF
--- a/transpiler/branch.go
+++ b/transpiler/branch.go
@@ -113,7 +113,7 @@ func transpileIfStmt(n *ast.IfStmt, p *program.Program) (
 		}
 	}
 
-	return r, newPre, newPost, nil
+	return r, preStmts, postStmts, nil
 }
 
 func transpileForStmt(n *ast.ForStmt, p *program.Program) (


### PR DESCRIPTION
```
IneffAssign detects ineffectual assignments in Go code.
c2go/transpiler/branch.go
Line 107: warning: preStmts assigned and not used (ineffassign)
Line 107: warning: postStmts assigned and not used (ineffassign)
```
Fix #404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/405)
<!-- Reviewable:end -->
