### PR TITLE
Error handling in function transpileUnaryOperatorMul

### DIFF
--- a/transpiler/unary.go
+++ b/transpiler/unary.go
@@ -152,6 +152,9 @@ func transpileUnaryOperatorMul(n *ast.UnaryOperator, p *program.Program) (
 	// pointers to slices, so we have to be careful when dereference a slice
 	// that it actually takes the first element instead.
 	resolvedType, err := types.ResolveType(p, eType)
+	if err != nil {
+		return nil, "", preStmts, postStmts, err
+	}
 	if strings.HasPrefix(resolvedType, "[]") {
 		return &goast.IndexExpr{
 			X:     e,


### PR DESCRIPTION
Fix #404
```
IneffAssign detects ineffectual assignments in Go code.
c2go/transpiler/unary.go
Line 154: warning: err assigned and not used (ineffassign)
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/406)
<!-- Reviewable:end -->
