### PR TITLE
Remove unused if statement for "type" as a variable name

### DIFF
--- a/tests/operators.c
+++ b/tests/operators.c
@@ -6,7 +6,7 @@
 
 int main()
 {
-	plan(35);
+	plan(36);
 
     int i = 10;
     signed char j = 1;
@@ -119,6 +119,10 @@ int main()
 	int s1 = ({ 2; });
 	is_eq(s1, 2);
 	is_eq(({ int foo = s1 * 3; foo + 1; }), 7);
+
+	diag("Not allowable var name for Go")
+	int type = 42;
+	is_eq(type,42);
 
 	done_testing();
 }

--- a/tests/struct.c
+++ b/tests/struct.c
@@ -60,7 +60,7 @@ struct xx {
 
 int main()
 {
-    plan(15);
+    plan(16);
 
     struct programming variable;
     char *s = "Programming in Software Development.";
@@ -115,6 +115,14 @@ int main()
 	struct u yy;
 	yy.y = 42;
 	is_eq(yy.y,42);
+
+	diag("Not allowable var name for Go")
+	struct type{
+		int type;
+	};
+	struct type t;
+	t.type = 42;
+	is_eq(t.type, 42);
 
     done_testing();
 }

--- a/transpiler/declarations.go
+++ b/transpiler/declarations.go
@@ -410,12 +410,6 @@ func transpileVarDecl(p *program.Program, n *ast.VarDecl) (decls []goast.Decl, t
 		return
 	}
 
-	// TODO: The name of a variable or field cannot be "type"
-	// https://github.com/elliotchance/c2go/issues/83
-	if name == "type" {
-		name = "type_"
-	}
-
 	defaultValue, _, newPre, newPost, err := getDefaultValueForVar(p, n)
 	if err != nil {
 		p.AddMessage(p.GenerateErrorMessage(err, n))


### PR DESCRIPTION
```
IneffAssign detects ineffectual assignments in Go code.
c2go/transpiler/declarations.go
Line 416: warning: name assigned and not used (ineffassign)
```
Fix #404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/407)
<!-- Reviewable:end -->
