### PR TITLE
 Use stringer interface for snapshots instead of []string 

### DIFF
--- a/.snapshots/c2go-TestCLI-func1-AstHelpFlag
+++ b/.snapshots/c2go-TestCLI-func1-AstHelpFlag
@@ -1,5 +1,3 @@
-([]string) (len=3) {
-  (string) (len=22) "Usage: test ast file.c",
-  (string) (len=27) "  -h\tprint help information",
-  (string) ""
-}
+(*bytes.Buffer)(Usage: test ast file.c
+  -h	print help information
+)

--- a/.snapshots/c2go-TestCLI-func1-AstNoFilesHelp
+++ b/.snapshots/c2go-TestCLI-func1-AstNoFilesHelp
@@ -1,5 +1,3 @@
-([]string) (len=3) {
-  (string) (len=22) "Usage: test ast file.c",
-  (string) (len=27) "  -h\tprint help information",
-  (string) ""
-}
+(*bytes.Buffer)(Usage: test ast file.c
+  -h	print help information
+)

--- a/.snapshots/c2go-TestCLI-func1-TranspileHelpFlag
+++ b/.snapshots/c2go-TestCLI-func1-TranspileHelpFlag
@@ -1,12 +1,10 @@
-([]string) (len=10) {
-  (string) (len=64) "Usage: test transpile [-V] [-o file.go] [-p package] file1.c ...",
-  (string) (len=31) "  -V\tprint progress as comments",
-  (string) (len=19) "  -clang-flag value",
-  (string) (len=73) "    \tPass arguments to clang. You may provide multiple -clang-flag items.",
-  (string) (len=27) "  -h\tprint help information",
-  (string) (len=11) "  -o string",
-  (string) (len=51) "    \toutput Go generated code to the specified file",
-  (string) (len=11) "  -p string",
-  (string) (len=59) "    \tset the name of the generated package (default \"main\")",
-  (string) ""
-}
+(*bytes.Buffer)(Usage: test transpile [-V] [-o file.go] [-p package] file1.c ...
+  -V	print progress as comments
+  -clang-flag value
+    	Pass arguments to clang. You may provide multiple -clang-flag items.
+  -h	print help information
+  -o string
+    	output Go generated code to the specified file
+  -p string
+    	set the name of the generated package (default "main")
+)

--- a/.snapshots/c2go-TestCLI-func1-TranspileNoFilesHelp
+++ b/.snapshots/c2go-TestCLI-func1-TranspileNoFilesHelp
@@ -1,12 +1,10 @@
-([]string) (len=10) {
-  (string) (len=64) "Usage: test transpile [-V] [-o file.go] [-p package] file1.c ...",
-  (string) (len=31) "  -V\tprint progress as comments",
-  (string) (len=19) "  -clang-flag value",
-  (string) (len=73) "    \tPass arguments to clang. You may provide multiple -clang-flag items.",
-  (string) (len=27) "  -h\tprint help information",
-  (string) (len=11) "  -o string",
-  (string) (len=51) "    \toutput Go generated code to the specified file",
-  (string) (len=11) "  -p string",
-  (string) (len=59) "    \tset the name of the generated package (default \"main\")",
-  (string) ""
-}
+(*bytes.Buffer)(Usage: test transpile [-V] [-o file.go] [-p package] file1.c ...
+  -V	print progress as comments
+  -clang-flag value
+    	Pass arguments to clang. You may provide multiple -clang-flag items.
+  -h	print help information
+  -o string
+    	output Go generated code to the specified file
+  -p string
+    	set the name of the generated package (default "main")
+)

--- a/cli_test.go
+++ b/cli_test.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
-	"github.com/bradleyjkemp/cupaloy"
 	"os"
-	"strings"
 	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
 )
 
 func setupTest(args []string) (*bytes.Buffer, func()) {
@@ -43,8 +43,8 @@ func TestCLI(t *testing.T) {
 			defer teardown()
 
 			runCommand()
-			outputLines := strings.Split(output.String(), "\n")
-			err := cupaloy.SnapshotMulti(testName, outputLines)
+
+			err := cupaloy.SnapshotMulti(testName, output)
 			if err != nil {
 				t.Fatalf("error: %s", err)
 			}


### PR DESCRIPTION
Realised that *bytes.Buffer already implements the Stringer interface and so we don't need to split the output into lines ourselves (and as a result we now get that formatting/alignment is preserved)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/446)
<!-- Reviewable:end -->
