### PR TITLE
Show original location of transpiled functions. Fixes #536

### DIFF
--- a/ast/position.go
+++ b/ast/position.go
@@ -19,10 +19,6 @@ type Position struct {
 	StringValue string
 }
 
-func (pos Position) String() string {
-	return fmt.Sprintf("File : %s; Line : %d", pos.File, pos.Line)
-}
-
 func NewPositionFromString(s string) Position {
 	if s == "<invalid sloc>" || s == "" {
 		return Position{}

--- a/ast/position.go
+++ b/ast/position.go
@@ -19,6 +19,10 @@ type Position struct {
 	StringValue string
 }
 
+func (pos Position) String() string {
+	return fmt.Sprintf("File : %s; Line : %d", pos.File, pos.Line)
+}
+
 func NewPositionFromString(s string) Position {
 	if s == "<invalid sloc>" || s == "" {
 		return Position{}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -466,6 +466,9 @@ func transpileToNode(node ast.Node, p *program.Program) (decls []goast.Decl, err
 		if len(decls) > 0 {
 			if _, ok := decls[0].(*goast.FuncDecl); ok {
 				decls[0].(*goast.FuncDecl).Doc = p.GetMessageComments()
+				decls[0].(*goast.FuncDecl).Doc.List = append(decls[0].(*goast.FuncDecl).Doc.List, &goast.Comment{
+					Text: fmt.Sprintf("// Info : %v", n.Pos),
+				})
 			}
 		}
 

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -467,7 +467,7 @@ func transpileToNode(node ast.Node, p *program.Program) (decls []goast.Decl, err
 			if _, ok := decls[0].(*goast.FuncDecl); ok {
 				decls[0].(*goast.FuncDecl).Doc = p.GetMessageComments()
 				decls[0].(*goast.FuncDecl).Doc.List = append(decls[0].(*goast.FuncDecl).Doc.List, &goast.Comment{
-					Text: fmt.Sprintf("// Info : %v", n.Pos),
+					Text: fmt.Sprintf("// Info - location of function, file : %s , line : %d", n.Pos.File, n.Pos.Line),
 				})
 			}
 		}

--- a/transpiler/transpiler.go
+++ b/transpiler/transpiler.go
@@ -466,9 +466,9 @@ func transpileToNode(node ast.Node, p *program.Program) (decls []goast.Decl, err
 		if len(decls) > 0 {
 			if _, ok := decls[0].(*goast.FuncDecl); ok {
 				decls[0].(*goast.FuncDecl).Doc = p.GetMessageComments()
-				decls[0].(*goast.FuncDecl).Doc.List = append(decls[0].(*goast.FuncDecl).Doc.List, &goast.Comment{
-					Text: fmt.Sprintf("// Info - location of function, file : %s , line : %d", n.Pos.File, n.Pos.Line),
-				})
+				decls[0].(*goast.FuncDecl).Doc.List = append([]*goast.Comment{&goast.Comment{
+					Text: fmt.Sprintf("// %s - transpiled function from file : %s , line : %d", decls[0].(*goast.FuncDecl).Name.Name, n.Pos.File, n.Pos.Line),
+				}}, decls[0].(*goast.FuncDecl).Doc.List...)
 			}
 		}
 


### PR DESCRIPTION
Close #536 
Example:
```go
// approxf - transpiled function from file : tests/tests.h , line : 40
func approxf(actual float64, expected float64, bits int) int {
	if (func() int {
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/540)
<!-- Reviewable:end -->

  