### PR TITLE
Custom character literal parsing. Fixes #663

### DIFF
--- a/ast/character_literal.go
+++ b/ast/character_literal.go
@@ -1,7 +1,11 @@
 package ast
 
 import (
+	"errors"
+	"fmt"
+	"github.com/elliotchance/c2go/cc"
 	"github.com/elliotchance/c2go/util"
+	"reflect"
 )
 
 // CharacterLiteral is type of character literal
@@ -49,4 +53,71 @@ func (n *CharacterLiteral) Children() []Node {
 // Position returns the position in the original source code.
 func (n *CharacterLiteral) Position() Position {
 	return n.Pos
+}
+
+// CharacterLiteralError represents one instance of an error where the exact
+// character value of a CharacterLiteral could not be determined from the
+// original source. See RepairCharacterLiteralsFromSource for a full explanation.
+type CharacterLiteralError struct {
+	Node *CharacterLiteral
+	Err  error
+}
+
+// RepairCharacterLiteralsFromSource finds the exact values of character literals
+// by reading their values directly from the preprocessed source.
+//
+// This is to solve issue #663, sometime clang serializes hex encoded character literals
+// as a weird number, e.g. '\xa0' => 4294967200
+//
+// The only solution is to read the original character literal from the source
+// code. We can do this by using the positional information on the node.
+//
+// If the character literal cannot be resolved for any reason the original value
+// will remain. This function will return all errors encountered.
+func RepairCharacterLiteralsFromSource(rootNode Node, preprocessedFile string) []CharacterLiteralError {
+	errs := []CharacterLiteralError{}
+	characterLiteralNodes :=
+		GetAllNodesOfType(rootNode, reflect.TypeOf((*CharacterLiteral)(nil)))
+
+	for _, node := range characterLiteralNodes {
+		cNode := node.(*CharacterLiteral)
+
+		// Use the node position to retrieve the original line from the
+		// preprocessed source.
+		pos := node.Position()
+		line, err :=
+			cc.GetLineFromPreprocessedFile(preprocessedFile, pos.File, pos.Line)
+
+		// If there was a problem reading the line we should raise a warning and
+		// use the value we have. Hopefully that will be an accurate enough
+		// representation.
+		if err != nil {
+			errs = append(errs, CharacterLiteralError{
+				Node: cNode,
+				Err:  err,
+			})
+		}
+
+		// Extract the exact value from the line.
+		if pos.Column-1 >= len(line) {
+			errs = append(errs, CharacterLiteralError{
+				Node: cNode,
+				Err:  errors.New("cannot get exact value"),
+			})
+		} else {
+			var i int
+			literal := line[pos.Column-1:]
+			if _, err := fmt.Sscan(literal, &i); err == nil {
+				cNode.Value = i
+			} else {
+				errs = append(errs, CharacterLiteralError{
+					Node: cNode,
+					Err:  fmt.Errorf("cannot parse character literal: %v from %s", err, literal),
+				})
+			}
+			fmt.Sscan(line[pos.Column-1:], &cNode.Value)
+		}
+	}
+
+	return errs
 }

--- a/ast/character_literal.go
+++ b/ast/character_literal.go
@@ -271,16 +271,16 @@ func decodeUCN(runes []rune) (rune, int) {
 	switch runes[0] {
 	case 'u':
 		hq, n := decodeHexQuad(runes[1:])
-		return rune(hq), n+2
+		return rune(hq), n + 2
 	case 'U':
 		hq, n := decodeHexQuad(runes[1:])
 		if n == 4 {
 			hq2, n2 := decodeHexQuad(runes[5:])
-			hq = hq << (4*uint(n2))
+			hq = hq << (4 * uint(n2))
 			hq = hq | hq2
 			n = n + n2
 		}
-		return rune(hq), n+2
+		return rune(hq), n + 2
 	default:
 		panic("internal error")
 	}

--- a/ast/character_literal_test.go
+++ b/ast/character_literal_test.go
@@ -2,6 +2,11 @@ package ast
 
 import (
 	"testing"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"github.com/elliotchance/c2go/cc"
 )
 
 func TestCharacterLiteral(t *testing.T) {
@@ -16,4 +21,339 @@ func TestCharacterLiteral(t *testing.T) {
 	}
 
 	runNodeTests(t, nodes)
+}
+
+func TestCharacterLiteralDecodeHex(t *testing.T) {
+	hexCodes := map[rune]int {
+		'0': 0,
+		'1': 1,
+		'2': 2,
+		'3': 3,
+		'4': 4,
+		'5': 5,
+		'6': 6,
+		'7': 7,
+		'8': 8,
+		'9': 9,
+		'a': 10,
+		'b': 11,
+		'c': 12,
+		'd': 13,
+		'e': 14,
+		'f': 15,
+		'A': 10,
+		'B': 11,
+		'C': 12,
+		'D': 13,
+		'E': 14,
+		'F': 15,
+		'z': -1, // illegal hex characters return -1
+		'G': -1,
+	}
+	for r, expected := range hexCodes {
+		i := decodeHex(r)
+
+		if i != expected {
+			t.Errorf("hexDecode should match: expected: %d, got: %d", expected, i)
+		}
+	}
+}
+
+func TestCharacterLiteralDecodeHexQuad(t *testing.T) {
+	runes := map[string][]int {
+		"zzzzzz": {0, 0},
+		"1zzzzz": {0x1, 1},
+		"1Azzzz": {0x1a, 2},
+		"1A3zzz": {0x1a3, 3},
+		"1A3bzz": {0x1a3b, 4},
+		"1A3b5z": {0x1a3b, 4},
+		"1A3b": {0x1a3b, 4},
+		"1A3": {0x1a3, 3},
+		"1A": {0x1a, 2},
+		"1": {0x1, 1},
+		"": {0, 0},
+	}
+	for r, expected := range runes {
+		i, n := decodeHexQuad([]rune(r))
+
+		if int(i) != expected[0] {
+			t.Errorf("hexDecodeQuad('%s') should match: expected: %x, got: %x", r, expected[0], i)
+		}
+		if n != expected[1] {
+			t.Errorf("hexDecodeQuad('%s') length should match: expected: %d, got: %d", r, expected[1], n)
+		}
+	}
+}
+
+func TestCharacterLiteralDecodeUCN(t *testing.T) {
+	runes := map[string][]int {
+		"\\uzzzzzz": {0, 2},
+		"\\u1zzzzz": {0x1, 3},
+		"\\u1Azzzz": {0x1a, 4},
+		"\\u1A3zzz": {0x1a3, 5},
+		"\\u1A3bzz": {0x1a3b, 6},
+		"\\u1A3b5z": {0x1a3b, 6},
+		"\\u1A3b": {0x1a3b, 6},
+		"\\u1A3": {0x1a3, 5},
+		"\\u1A": {0x1a, 4},
+		"\\u1": {0x1, 3},
+		"\\u": {0, 2},
+		"\\Uzzzzzzzzzz": {0, 2},
+		"\\U1zzzzzzzzz": {0x1, 3},
+		"\\U1Azzzzzzzz": {0x1a, 4},
+		"\\U1A3zzzzzzz": {0x1a3, 5},
+		"\\U1A3bzzzzzz": {0x1a3b, 6},
+		"\\U1A3b5zzzzz": {0x1a3b5, 7},
+		"\\U1A3b52zzzz": {0x1a3b52, 8},
+		"\\U1A3b52fzzz": {0x1a3b52f, 9},
+		"\\U1A3b52f6zz": {0x1a3b52f6, 10},
+		"\\U1A3b52f69z": {0x1a3b52f6, 10},
+		"\\U1A3b52f6": {0x1a3b52f6, 10},
+		"\\U1A3b52f": {0x1a3b52f, 9},
+		"\\U1A3b52": {0x1a3b52, 8},
+		"\\U1A3b5": {0x1a3b5, 7},
+		"\\U1A3b": {0x1a3b, 6},
+		"\\U1A3": {0x1a3, 5},
+		"\\U1A": {0x1a, 4},
+		"\\U1": {0x1, 3},
+		"\\U": {0, 2},
+	}
+	for r, expected := range runes {
+		i, n := decodeUCN([]rune(r))
+
+		if int(i) != expected[0] {
+			t.Errorf("decodeUCN('%s') should match: expected: %x, got: %x", r, expected[0], int(i))
+		}
+		if n != expected[1] {
+			t.Errorf("decodeUCN('%s') length should match: expected: %d, got: %d", r, expected[1], n)
+		}
+	}
+}
+
+func TestCharacterLiteralDecodeEscapeSequence(t *testing.T) {
+	type test struct {
+		result int
+		length int
+		err error
+	}
+	runes := map[string]test {
+		"\\'zz": {int('\''), 2, nil},
+		"\\\"zz": {int('"'), 2, nil},
+		"\\?zz": {int('?'), 2, nil},
+		"\\\\zz": {int('\\'), 2, nil},
+		"\\azz": {int('\a'), 2, nil},
+		"\\bzz": {int('\b'), 2, nil},
+		"\\fzz": {int('\f'), 2, nil},
+		"\\nzz": {int('\n'), 2, nil},
+		"\\rzz": {int('\r'), 2, nil},
+		"\\tzz": {int('\t'), 2, nil},
+		"\\vzz": {int('\v'), 2, nil},
+		"\\'": {int('\''), 2, nil},
+		"\\\"": {int('"'), 2, nil},
+		"\\?": {int('?'), 2, nil},
+		"\\\\": {int('\\'), 2, nil},
+		"\\a": {int('\a'), 2, nil},
+		"\\b": {int('\b'), 2, nil},
+		"\\f": {int('\f'), 2, nil},
+		"\\n": {int('\n'), 2, nil},
+		"\\r": {int('\r'), 2, nil},
+		"\\t": {int('\t'), 2, nil},
+		"\\v": {int('\v'), 2, nil},
+		"\\xzzzzzz": {0, 2, nil},
+		"\\x3zzzzz": {0x3, 3, nil},
+		"\\x3bzzzz": {0x3b, 4, nil},
+		"\\x3b1zzz": {0x3b, 4, nil},
+		"\\x3b": {0x3b, 4, nil},
+		"\\x3": {0x3, 3, nil},
+		"\\x": {0, 2, nil},
+		"\\zzzzzz": {0, 0, fmt.Errorf("illegal character '%s'", "z")},
+		"\\dzzzzz": {0, 0, fmt.Errorf("illegal character '%s'", "d")},
+		"\\9zzzzz": {0, 0, fmt.Errorf("illegal character '%s'", "9")},
+		"\\z": {0, 0, fmt.Errorf("illegal character '%s'", "z")},
+		"\\d": {0, 0, fmt.Errorf("illegal character '%s'", "d")},
+		"\\9": {0, 0, fmt.Errorf("illegal character '%s'", "9")},
+		"\\0zzzzzz": {0, 2, nil},
+		"\\1zzzzzz": {1, 2, nil},
+		"\\2zzzzzz": {2, 2, nil},
+		"\\3zzzzzz": {3, 2, nil},
+		"\\4zzzzzz": {4, 2, nil},
+		"\\5zzzzzz": {5, 2, nil},
+		"\\6zzzzzz": {6, 2, nil},
+		"\\7zzzzzz": {7, 2, nil},
+		"\\0": {0, 2, nil},
+		"\\1": {1, 2, nil},
+		"\\2": {2, 2, nil},
+		"\\3": {3, 2, nil},
+		"\\4": {4, 2, nil},
+		"\\5": {5, 2, nil},
+		"\\6": {6, 2, nil},
+		"\\7": {7, 2, nil},
+		"\\34zzzzzz": {034,3, nil},
+		"\\347zzzzz": {0347, 4, nil},
+		"\\3472zzzz": {0347, 4, nil},
+		"\\347": {0347, 4, nil},
+		"\\34": {034, 3, nil},
+		"\\uzzzzzz": {0, 2, nil},
+		"\\u1zzzzz": {0x1, 3, nil},
+		"\\u1Azzzz": {0x1a, 4, nil},
+		"\\u1A3zzz": {0x1a3, 5, nil},
+		"\\u1A3bzz": {0x1a3b, 6, nil},
+		"\\u1A3b5z": {0x1a3b, 6, nil},
+		"\\u1A3b": {0x1a3b, 6, nil},
+		"\\u1A3": {0x1a3, 5, nil},
+		"\\u1A": {0x1a, 4, nil},
+		"\\u1": {0x1, 3, nil},
+		"\\u": {0, 2, nil},
+		"\\Uzzzzzzzzzz": {0, 2, nil},
+		"\\U1zzzzzzzzz": {0x1, 3, nil},
+		"\\U1Azzzzzzzz": {0x1a, 4, nil},
+		"\\U1A3zzzzzzz": {0x1a3, 5, nil},
+		"\\U1A3bzzzzzz": {0x1a3b, 6, nil},
+		"\\U1A3b5zzzzz": {0x1a3b5, 7, nil},
+		"\\U1A3b52zzzz": {0x1a3b52, 8, nil},
+		"\\U1A3b52fzzz": {0x1a3b52f, 9, nil},
+		"\\U1A3b52f6zz": {0x1a3b52f6, 10, nil},
+		"\\U1A3b52f69z": {0x1a3b52f6, 10, nil},
+		"\\U1A3b52f6": {0x1a3b52f6, 10, nil},
+		"\\U1A3b52f": {0x1a3b52f, 9, nil},
+		"\\U1A3b52": {0x1a3b52, 8, nil},
+		"\\U1A3b5": {0x1a3b5, 7, nil},
+		"\\U1A3b": {0x1a3b, 6, nil},
+		"\\U1A3": {0x1a3, 5, nil},
+		"\\U1A": {0x1a, 4, nil},
+		"\\U1": {0x1, 3, nil},
+		"\\U": {0, 2, nil},
+	}
+	for r, expected := range runes {
+		i, n, err := decodeEscapeSequence([]rune(r))
+
+		if int(i) != expected.result {
+			t.Errorf("decodeEscapeSequence('%s') should match: expected: %x, got: %x", r, expected.result, int(i))
+		}
+		if n != expected.length {
+			t.Errorf("decodeEscapeSequence('%s') length should match: expected: %d, got: %d", r, expected.length, n)
+		}
+		if err != nil && expected.err == nil || err == nil && expected.err != nil {
+			t.Errorf("decodeEscapeSequence('%s') error should match: expected: %v, got: %v", r, expected.err, err)
+		} else if err != nil && err.Error() != expected.err.Error() {
+			t.Errorf("decodeEscapeSequence('%s') error should match: expected: %s, got: %s", r, expected.err.Error(), err.Error())
+		}
+	}
+}
+
+func TestCharacterLiteralFromSource(t *testing.T) {
+	type test struct {
+		result int
+		err error
+	}
+	prefixes := map[string]error {
+		"'": nil,
+		"u'": nil,
+		"u8'": nil,
+		"U'": nil,
+		"L'": nil,
+		"z": fmt.Errorf("illegal character 'z' at index 0"),
+		"uz": fmt.Errorf("illegal character 'z' at index 1"),
+		"Uz": fmt.Errorf("illegal character 'z' at index 1"),
+		"Lz": fmt.Errorf("illegal character 'z' at index 1"),
+		"u8z": fmt.Errorf("illegal character 'z' at index 2"),
+	}
+	suffixes := map[string]test{
+		"": {0, fmt.Errorf("unexpected end of character literal")},
+		"'": {0, fmt.Errorf("empty character literal")},
+		"a'": {int('a'), nil},
+		"a": {0, fmt.Errorf("unexpected end of character literal")},
+		"\\": {0, fmt.Errorf("unexpected end of character literal")},
+		"\\'": {0, fmt.Errorf("unexpected end of character literal")},
+		"\\''": {int('\''), nil},
+		"ab": {0, fmt.Errorf("does not support multi-character literals")},
+		"\\nb": {0, fmt.Errorf("does not support multi-character literals")},
+	}
+	tests := map[string]test{
+		"": {0, fmt.Errorf("character literal to short")},
+		"u": {0, fmt.Errorf("character literal to short")},
+		"u8": {0, fmt.Errorf("character literal to short")},
+		"U": {0, fmt.Errorf("character literal to short")},
+		"L": {0, fmt.Errorf("character literal to short")},
+	}
+	for i, x := range prefixes {
+		for j, y := range suffixes {
+			var t = y
+			str := i+j
+			if x != nil {
+				t.result = 0
+				t.err = x
+			}
+			tests[str] = t
+		}
+	}
+	for s, expected := range tests {
+		i, err := parseCharacterLiteralFromSource(s)
+
+		if int(i) != expected.result {
+			t.Errorf("parseCharacterLiteralFromSource('%s') should match: expected: %x, got: %x", s, expected.result, int(i))
+		}
+		if err != nil && expected.err == nil || err == nil && expected.err != nil {
+			t.Errorf("parseCharacterLiteralFromSource('%s') error should match: expected: %v, got: %v", s, expected.err, err)
+		} else if err != nil && err.Error() != expected.err.Error() {
+			t.Errorf("parseCharacterLiteralFromSource('%s') error should match: expected: %s, got: %s", s, expected.err.Error(), err.Error())
+		}
+	}
+}
+
+func TestCharacterLiteralRepairFromSource(t *testing.T) {
+	cl := &CharacterLiteral{
+		Addr:       0x7f980b858308,
+		Pos:        NewPositionFromString("col:12"),
+		Type:       "int",
+		Value:      10,
+		ChildNodes: []Node{},
+	}
+	root := &CompoundStmt{
+		Pos:        Position{File: "dummy.c", Line: 5},
+		ChildNodes: []Node{cl},
+	}
+	FixPositions([]Node{root})
+	type test struct {
+		file     string
+		expected int
+		err      error
+	}
+	tests := []test{
+		{ "# 2 \"x.c\"\n\n", 10, fmt.Errorf("could not find file %s", "dummy.c") },
+		{ "# 2 \"x.c\"\n\n# 1 \"dummy.c\"ff\nxxxxx\n\nyyyy", 10, fmt.Errorf("could not find %s:%d", "dummy.c", 5) },
+		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = \nyyyy", 10, fmt.Errorf("cannot get exact value") },
+		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = u\nyyyy", 10, fmt.Errorf("cannot parse character literal: character literal to short from u") },
+		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = '\nyyyy", 10, fmt.Errorf("cannot parse character literal: unexpected end of character literal from '") },
+		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = ''zzz\nyyyy", 10, fmt.Errorf("cannot parse character literal: empty character literal from ''zzz") },
+		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = 'A'zzz\nyyyy", int('A'), nil },
+		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = 'B'\nyyyy", int('B'), nil },
+		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = '\\n'\nyyyy", int('\n'), nil },
+	}
+	for _, test := range tests {
+		func() {
+			cc.ResetCache()
+			dir, err := ioutil.TempDir("", "c2go")
+			if err != nil {
+				t.Fatal(fmt.Errorf("Cannot create temp folder: %v", err))
+			}
+			defer os.RemoveAll(dir) // clean up
+
+			ppFilePath := path.Join(dir, "pp.c")
+			err = ioutil.WriteFile(ppFilePath, []byte(test.file), 0644)
+			if err != nil {
+				t.Fatal(fmt.Errorf("writing to %s failed: %v", ppFilePath, err))
+			}
+
+			errors := RepairCharacterLiteralsFromSource(root, ppFilePath)
+			if cl.Value != test.expected {
+				t.Errorf("RepairCharacterLiteralsFromSource - expected: %x, got: %x", test.expected, cl.Value)
+			}
+			if test.err != nil && len(errors)==0 || test.err == nil && len(errors)!=0 {
+				t.Errorf("RepairCharacterLiteralsFromSource - error should match: expected: %v, got: %v", test.err, errors)
+			} else if test.err != nil && errors[0].Err.Error() != test.err.Error() {
+				t.Errorf("RepairCharacterLiteralsFromSource - error should match: expected: %s, got: %s", test.err.Error(), errors[0].Err.Error())
+			}
+		}()
+	}
 }

--- a/ast/character_literal_test.go
+++ b/ast/character_literal_test.go
@@ -1,12 +1,12 @@
 package ast
 
 import (
-	"testing"
 	"fmt"
+	"github.com/elliotchance/c2go/cc"
 	"io/ioutil"
 	"os"
 	"path"
-	"github.com/elliotchance/c2go/cc"
+	"testing"
 )
 
 func TestCharacterLiteral(t *testing.T) {
@@ -24,7 +24,7 @@ func TestCharacterLiteral(t *testing.T) {
 }
 
 func TestCharacterLiteralDecodeHex(t *testing.T) {
-	hexCodes := map[rune]int {
+	hexCodes := map[rune]int{
 		'0': 0,
 		'1': 1,
 		'2': 2,
@@ -60,18 +60,18 @@ func TestCharacterLiteralDecodeHex(t *testing.T) {
 }
 
 func TestCharacterLiteralDecodeHexQuad(t *testing.T) {
-	runes := map[string][]int {
+	runes := map[string][]int{
 		"zzzzzz": {0, 0},
 		"1zzzzz": {0x1, 1},
 		"1Azzzz": {0x1a, 2},
 		"1A3zzz": {0x1a3, 3},
 		"1A3bzz": {0x1a3b, 4},
 		"1A3b5z": {0x1a3b, 4},
-		"1A3b": {0x1a3b, 4},
-		"1A3": {0x1a3, 3},
-		"1A": {0x1a, 2},
-		"1": {0x1, 1},
-		"": {0, 0},
+		"1A3b":   {0x1a3b, 4},
+		"1A3":    {0x1a3, 3},
+		"1A":     {0x1a, 2},
+		"1":      {0x1, 1},
+		"":       {0, 0},
 	}
 	for r, expected := range runes {
 		i, n := decodeHexQuad([]rune(r))
@@ -86,18 +86,18 @@ func TestCharacterLiteralDecodeHexQuad(t *testing.T) {
 }
 
 func TestCharacterLiteralDecodeUCN(t *testing.T) {
-	runes := map[string][]int {
-		"\\uzzzzzz": {0, 2},
-		"\\u1zzzzz": {0x1, 3},
-		"\\u1Azzzz": {0x1a, 4},
-		"\\u1A3zzz": {0x1a3, 5},
-		"\\u1A3bzz": {0x1a3b, 6},
-		"\\u1A3b5z": {0x1a3b, 6},
-		"\\u1A3b": {0x1a3b, 6},
-		"\\u1A3": {0x1a3, 5},
-		"\\u1A": {0x1a, 4},
-		"\\u1": {0x1, 3},
-		"\\u": {0, 2},
+	runes := map[string][]int{
+		"\\uzzzzzz":     {0, 2},
+		"\\u1zzzzz":     {0x1, 3},
+		"\\u1Azzzz":     {0x1a, 4},
+		"\\u1A3zzz":     {0x1a3, 5},
+		"\\u1A3bzz":     {0x1a3b, 6},
+		"\\u1A3b5z":     {0x1a3b, 6},
+		"\\u1A3b":       {0x1a3b, 6},
+		"\\u1A3":        {0x1a3, 5},
+		"\\u1A":         {0x1a, 4},
+		"\\u1":          {0x1, 3},
+		"\\u":           {0, 2},
 		"\\Uzzzzzzzzzz": {0, 2},
 		"\\U1zzzzzzzzz": {0x1, 3},
 		"\\U1Azzzzzzzz": {0x1a, 4},
@@ -108,15 +108,15 @@ func TestCharacterLiteralDecodeUCN(t *testing.T) {
 		"\\U1A3b52fzzz": {0x1a3b52f, 9},
 		"\\U1A3b52f6zz": {0x1a3b52f6, 10},
 		"\\U1A3b52f69z": {0x1a3b52f6, 10},
-		"\\U1A3b52f6": {0x1a3b52f6, 10},
-		"\\U1A3b52f": {0x1a3b52f, 9},
-		"\\U1A3b52": {0x1a3b52, 8},
-		"\\U1A3b5": {0x1a3b5, 7},
-		"\\U1A3b": {0x1a3b, 6},
-		"\\U1A3": {0x1a3, 5},
-		"\\U1A": {0x1a, 4},
-		"\\U1": {0x1, 3},
-		"\\U": {0, 2},
+		"\\U1A3b52f6":   {0x1a3b52f6, 10},
+		"\\U1A3b52f":    {0x1a3b52f, 9},
+		"\\U1A3b52":     {0x1a3b52, 8},
+		"\\U1A3b5":      {0x1a3b5, 7},
+		"\\U1A3b":       {0x1a3b, 6},
+		"\\U1A3":        {0x1a3, 5},
+		"\\U1A":         {0x1a, 4},
+		"\\U1":          {0x1, 3},
+		"\\U":           {0, 2},
 	}
 	for r, expected := range runes {
 		i, n := decodeUCN([]rune(r))
@@ -134,76 +134,76 @@ func TestCharacterLiteralDecodeEscapeSequence(t *testing.T) {
 	type test struct {
 		result int
 		length int
-		err error
+		err    error
 	}
-	runes := map[string]test {
-		"\\'zz": {int('\''), 2, nil},
-		"\\\"zz": {int('"'), 2, nil},
-		"\\?zz": {int('?'), 2, nil},
-		"\\\\zz": {int('\\'), 2, nil},
-		"\\azz": {int('\a'), 2, nil},
-		"\\bzz": {int('\b'), 2, nil},
-		"\\fzz": {int('\f'), 2, nil},
-		"\\nzz": {int('\n'), 2, nil},
-		"\\rzz": {int('\r'), 2, nil},
-		"\\tzz": {int('\t'), 2, nil},
-		"\\vzz": {int('\v'), 2, nil},
-		"\\'": {int('\''), 2, nil},
-		"\\\"": {int('"'), 2, nil},
-		"\\?": {int('?'), 2, nil},
-		"\\\\": {int('\\'), 2, nil},
-		"\\a": {int('\a'), 2, nil},
-		"\\b": {int('\b'), 2, nil},
-		"\\f": {int('\f'), 2, nil},
-		"\\n": {int('\n'), 2, nil},
-		"\\r": {int('\r'), 2, nil},
-		"\\t": {int('\t'), 2, nil},
-		"\\v": {int('\v'), 2, nil},
-		"\\xzzzzzz": {0, 2, nil},
-		"\\x3zzzzz": {0x3, 3, nil},
-		"\\x3bzzzz": {0x3b, 4, nil},
-		"\\x3b1zzz": {0x3b, 4, nil},
-		"\\x3b": {0x3b, 4, nil},
-		"\\x3": {0x3, 3, nil},
-		"\\x": {0, 2, nil},
-		"\\zzzzzz": {0, 0, fmt.Errorf("illegal character '%s'", "z")},
-		"\\dzzzzz": {0, 0, fmt.Errorf("illegal character '%s'", "d")},
-		"\\9zzzzz": {0, 0, fmt.Errorf("illegal character '%s'", "9")},
-		"\\z": {0, 0, fmt.Errorf("illegal character '%s'", "z")},
-		"\\d": {0, 0, fmt.Errorf("illegal character '%s'", "d")},
-		"\\9": {0, 0, fmt.Errorf("illegal character '%s'", "9")},
-		"\\0zzzzzz": {0, 2, nil},
-		"\\1zzzzzz": {1, 2, nil},
-		"\\2zzzzzz": {2, 2, nil},
-		"\\3zzzzzz": {3, 2, nil},
-		"\\4zzzzzz": {4, 2, nil},
-		"\\5zzzzzz": {5, 2, nil},
-		"\\6zzzzzz": {6, 2, nil},
-		"\\7zzzzzz": {7, 2, nil},
-		"\\0": {0, 2, nil},
-		"\\1": {1, 2, nil},
-		"\\2": {2, 2, nil},
-		"\\3": {3, 2, nil},
-		"\\4": {4, 2, nil},
-		"\\5": {5, 2, nil},
-		"\\6": {6, 2, nil},
-		"\\7": {7, 2, nil},
-		"\\34zzzzzz": {034,3, nil},
-		"\\347zzzzz": {0347, 4, nil},
-		"\\3472zzzz": {0347, 4, nil},
-		"\\347": {0347, 4, nil},
-		"\\34": {034, 3, nil},
-		"\\uzzzzzz": {0, 2, nil},
-		"\\u1zzzzz": {0x1, 3, nil},
-		"\\u1Azzzz": {0x1a, 4, nil},
-		"\\u1A3zzz": {0x1a3, 5, nil},
-		"\\u1A3bzz": {0x1a3b, 6, nil},
-		"\\u1A3b5z": {0x1a3b, 6, nil},
-		"\\u1A3b": {0x1a3b, 6, nil},
-		"\\u1A3": {0x1a3, 5, nil},
-		"\\u1A": {0x1a, 4, nil},
-		"\\u1": {0x1, 3, nil},
-		"\\u": {0, 2, nil},
+	runes := map[string]test{
+		"\\'zz":         {int('\''), 2, nil},
+		"\\\"zz":        {int('"'), 2, nil},
+		"\\?zz":         {int('?'), 2, nil},
+		"\\\\zz":        {int('\\'), 2, nil},
+		"\\azz":         {int('\a'), 2, nil},
+		"\\bzz":         {int('\b'), 2, nil},
+		"\\fzz":         {int('\f'), 2, nil},
+		"\\nzz":         {int('\n'), 2, nil},
+		"\\rzz":         {int('\r'), 2, nil},
+		"\\tzz":         {int('\t'), 2, nil},
+		"\\vzz":         {int('\v'), 2, nil},
+		"\\'":           {int('\''), 2, nil},
+		"\\\"":          {int('"'), 2, nil},
+		"\\?":           {int('?'), 2, nil},
+		"\\\\":          {int('\\'), 2, nil},
+		"\\a":           {int('\a'), 2, nil},
+		"\\b":           {int('\b'), 2, nil},
+		"\\f":           {int('\f'), 2, nil},
+		"\\n":           {int('\n'), 2, nil},
+		"\\r":           {int('\r'), 2, nil},
+		"\\t":           {int('\t'), 2, nil},
+		"\\v":           {int('\v'), 2, nil},
+		"\\xzzzzzz":     {0, 2, nil},
+		"\\x3zzzzz":     {0x3, 3, nil},
+		"\\x3bzzzz":     {0x3b, 4, nil},
+		"\\x3b1zzz":     {0x3b, 4, nil},
+		"\\x3b":         {0x3b, 4, nil},
+		"\\x3":          {0x3, 3, nil},
+		"\\x":           {0, 2, nil},
+		"\\zzzzzz":      {0, 0, fmt.Errorf("illegal character '%s'", "z")},
+		"\\dzzzzz":      {0, 0, fmt.Errorf("illegal character '%s'", "d")},
+		"\\9zzzzz":      {0, 0, fmt.Errorf("illegal character '%s'", "9")},
+		"\\z":           {0, 0, fmt.Errorf("illegal character '%s'", "z")},
+		"\\d":           {0, 0, fmt.Errorf("illegal character '%s'", "d")},
+		"\\9":           {0, 0, fmt.Errorf("illegal character '%s'", "9")},
+		"\\0zzzzzz":     {0, 2, nil},
+		"\\1zzzzzz":     {1, 2, nil},
+		"\\2zzzzzz":     {2, 2, nil},
+		"\\3zzzzzz":     {3, 2, nil},
+		"\\4zzzzzz":     {4, 2, nil},
+		"\\5zzzzzz":     {5, 2, nil},
+		"\\6zzzzzz":     {6, 2, nil},
+		"\\7zzzzzz":     {7, 2, nil},
+		"\\0":           {0, 2, nil},
+		"\\1":           {1, 2, nil},
+		"\\2":           {2, 2, nil},
+		"\\3":           {3, 2, nil},
+		"\\4":           {4, 2, nil},
+		"\\5":           {5, 2, nil},
+		"\\6":           {6, 2, nil},
+		"\\7":           {7, 2, nil},
+		"\\34zzzzzz":    {034, 3, nil},
+		"\\347zzzzz":    {0347, 4, nil},
+		"\\3472zzzz":    {0347, 4, nil},
+		"\\347":         {0347, 4, nil},
+		"\\34":          {034, 3, nil},
+		"\\uzzzzzz":     {0, 2, nil},
+		"\\u1zzzzz":     {0x1, 3, nil},
+		"\\u1Azzzz":     {0x1a, 4, nil},
+		"\\u1A3zzz":     {0x1a3, 5, nil},
+		"\\u1A3bzz":     {0x1a3b, 6, nil},
+		"\\u1A3b5z":     {0x1a3b, 6, nil},
+		"\\u1A3b":       {0x1a3b, 6, nil},
+		"\\u1A3":        {0x1a3, 5, nil},
+		"\\u1A":         {0x1a, 4, nil},
+		"\\u1":          {0x1, 3, nil},
+		"\\u":           {0, 2, nil},
 		"\\Uzzzzzzzzzz": {0, 2, nil},
 		"\\U1zzzzzzzzz": {0x1, 3, nil},
 		"\\U1Azzzzzzzz": {0x1a, 4, nil},
@@ -214,15 +214,15 @@ func TestCharacterLiteralDecodeEscapeSequence(t *testing.T) {
 		"\\U1A3b52fzzz": {0x1a3b52f, 9, nil},
 		"\\U1A3b52f6zz": {0x1a3b52f6, 10, nil},
 		"\\U1A3b52f69z": {0x1a3b52f6, 10, nil},
-		"\\U1A3b52f6": {0x1a3b52f6, 10, nil},
-		"\\U1A3b52f": {0x1a3b52f, 9, nil},
-		"\\U1A3b52": {0x1a3b52, 8, nil},
-		"\\U1A3b5": {0x1a3b5, 7, nil},
-		"\\U1A3b": {0x1a3b, 6, nil},
-		"\\U1A3": {0x1a3, 5, nil},
-		"\\U1A": {0x1a, 4, nil},
-		"\\U1": {0x1, 3, nil},
-		"\\U": {0, 2, nil},
+		"\\U1A3b52f6":   {0x1a3b52f6, 10, nil},
+		"\\U1A3b52f":    {0x1a3b52f, 9, nil},
+		"\\U1A3b52":     {0x1a3b52, 8, nil},
+		"\\U1A3b5":      {0x1a3b5, 7, nil},
+		"\\U1A3b":       {0x1a3b, 6, nil},
+		"\\U1A3":        {0x1a3, 5, nil},
+		"\\U1A":         {0x1a, 4, nil},
+		"\\U1":          {0x1, 3, nil},
+		"\\U":           {0, 2, nil},
 	}
 	for r, expected := range runes {
 		i, n, err := decodeEscapeSequence([]rune(r))
@@ -244,42 +244,42 @@ func TestCharacterLiteralDecodeEscapeSequence(t *testing.T) {
 func TestCharacterLiteralFromSource(t *testing.T) {
 	type test struct {
 		result int
-		err error
+		err    error
 	}
-	prefixes := map[string]error {
-		"'": nil,
-		"u'": nil,
+	prefixes := map[string]error{
+		"'":   nil,
+		"u'":  nil,
 		"u8'": nil,
-		"U'": nil,
-		"L'": nil,
-		"z": fmt.Errorf("illegal character 'z' at index 0"),
-		"uz": fmt.Errorf("illegal character 'z' at index 1"),
-		"Uz": fmt.Errorf("illegal character 'z' at index 1"),
-		"Lz": fmt.Errorf("illegal character 'z' at index 1"),
+		"U'":  nil,
+		"L'":  nil,
+		"z":   fmt.Errorf("illegal character 'z' at index 0"),
+		"uz":  fmt.Errorf("illegal character 'z' at index 1"),
+		"Uz":  fmt.Errorf("illegal character 'z' at index 1"),
+		"Lz":  fmt.Errorf("illegal character 'z' at index 1"),
 		"u8z": fmt.Errorf("illegal character 'z' at index 2"),
 	}
 	suffixes := map[string]test{
-		"": {0, fmt.Errorf("unexpected end of character literal")},
-		"'": {0, fmt.Errorf("empty character literal")},
-		"a'": {int('a'), nil},
-		"a": {0, fmt.Errorf("unexpected end of character literal")},
-		"\\": {0, fmt.Errorf("unexpected end of character literal")},
-		"\\'": {0, fmt.Errorf("unexpected end of character literal")},
+		"":     {0, fmt.Errorf("unexpected end of character literal")},
+		"'":    {0, fmt.Errorf("empty character literal")},
+		"a'":   {int('a'), nil},
+		"a":    {0, fmt.Errorf("unexpected end of character literal")},
+		"\\":   {0, fmt.Errorf("unexpected end of character literal")},
+		"\\'":  {0, fmt.Errorf("unexpected end of character literal")},
 		"\\''": {int('\''), nil},
-		"ab": {0, fmt.Errorf("does not support multi-character literals")},
+		"ab":   {0, fmt.Errorf("does not support multi-character literals")},
 		"\\nb": {0, fmt.Errorf("does not support multi-character literals")},
 	}
 	tests := map[string]test{
-		"": {0, fmt.Errorf("character literal to short")},
-		"u": {0, fmt.Errorf("character literal to short")},
+		"":   {0, fmt.Errorf("character literal to short")},
+		"u":  {0, fmt.Errorf("character literal to short")},
 		"u8": {0, fmt.Errorf("character literal to short")},
-		"U": {0, fmt.Errorf("character literal to short")},
-		"L": {0, fmt.Errorf("character literal to short")},
+		"U":  {0, fmt.Errorf("character literal to short")},
+		"L":  {0, fmt.Errorf("character literal to short")},
 	}
 	for i, x := range prefixes {
 		for j, y := range suffixes {
 			var t = y
-			str := i+j
+			str := i + j
 			if x != nil {
 				t.result = 0
 				t.err = x
@@ -320,15 +320,15 @@ func TestCharacterLiteralRepairFromSource(t *testing.T) {
 		err      error
 	}
 	tests := []test{
-		{ "# 2 \"x.c\"\n\n", 10, fmt.Errorf("could not find file %s", "dummy.c") },
-		{ "# 2 \"x.c\"\n\n# 1 \"dummy.c\"ff\nxxxxx\n\nyyyy", 10, fmt.Errorf("could not find %s:%d", "dummy.c", 5) },
-		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = \nyyyy", 10, fmt.Errorf("cannot get exact value") },
-		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = u\nyyyy", 10, fmt.Errorf("cannot parse character literal: character literal to short from u") },
-		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = '\nyyyy", 10, fmt.Errorf("cannot parse character literal: unexpected end of character literal from '") },
-		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = ''zzz\nyyyy", 10, fmt.Errorf("cannot parse character literal: empty character literal from ''zzz") },
-		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = 'A'zzz\nyyyy", int('A'), nil },
-		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = 'B'\nyyyy", int('B'), nil },
-		{ "# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = '\\n'\nyyyy", int('\n'), nil },
+		{"# 2 \"x.c\"\n\n", 10, fmt.Errorf("could not find file %s", "dummy.c")},
+		{"# 2 \"x.c\"\n\n# 1 \"dummy.c\"ff\nxxxxx\n\nyyyy", 10, fmt.Errorf("could not find %s:%d", "dummy.c", 5)},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = \nyyyy", 10, fmt.Errorf("cannot get exact value")},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = u\nyyyy", 10, fmt.Errorf("cannot parse character literal: character literal to short from u")},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = '\nyyyy", 10, fmt.Errorf("cannot parse character literal: unexpected end of character literal from '")},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = ''zzz\nyyyy", 10, fmt.Errorf("cannot parse character literal: empty character literal from ''zzz")},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = 'A'zzz\nyyyy", int('A'), nil},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = 'B'\nyyyy", int('B'), nil},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = '\\n'\nyyyy", int('\n'), nil},
 	}
 	for _, test := range tests {
 		func() {
@@ -349,7 +349,7 @@ func TestCharacterLiteralRepairFromSource(t *testing.T) {
 			if cl.Value != test.expected {
 				t.Errorf("RepairCharacterLiteralsFromSource - expected: %x, got: %x", test.expected, cl.Value)
 			}
-			if test.err != nil && len(errors)==0 || test.err == nil && len(errors)!=0 {
+			if test.err != nil && len(errors) == 0 || test.err == nil && len(errors) != 0 {
 				t.Errorf("RepairCharacterLiteralsFromSource - error should match: expected: %v, got: %v", test.err, errors)
 			} else if test.err != nil && errors[0].Err.Error() != test.err.Error() {
 				t.Errorf("RepairCharacterLiteralsFromSource - error should match: expected: %s, got: %s", test.err.Error(), errors[0].Err.Error())

--- a/ast/floating_literal.go
+++ b/ast/floating_literal.go
@@ -103,10 +103,19 @@ func RepairFloatingLiteralsFromSource(rootNode Node, preprocessedFile string) []
 		if pos.Column-1 >= len(line) {
 			errs = append(errs, FloatingLiteralError{
 				Node: fNode,
-				Err:  errors.New("cannot get exact value exact value"),
+				Err:  errors.New("cannot get exact value"),
 			})
 		} else {
-			fmt.Sscan(line[pos.Column-1:], &fNode.Value)
+			var f float64
+			literal := line[pos.Column-1:]
+			if _, err := fmt.Sscan(literal, &f); err == nil {
+				fNode.Value = f
+			} else {
+				errs = append(errs, FloatingLiteralError{
+					Node: fNode,
+					Err:  fmt.Errorf("cannot parse float: %v from %s", err, literal),
+				})
+			}
 		}
 	}
 

--- a/ast/floating_literal_test.go
+++ b/ast/floating_literal_test.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -23,4 +24,47 @@ func TestFloatingLiteral(t *testing.T) {
 	}
 
 	runNodeTests(t, nodes)
+}
+
+func TestFloatingLiteralRepairFromSource(t *testing.T) {
+	fl := &FloatingLiteral{
+		Addr:       0x7febe106f5e8,
+		Pos:        NewPositionFromString("col:12"),
+		Type:       "double",
+		Value:      1.23,
+		ChildNodes: []Node{},
+	}
+	root := &CompoundStmt{
+		Pos:        Position{File: "dummy.c", Line: 5},
+		ChildNodes: []Node{fl},
+	}
+	FixPositions([]Node{root})
+	type test struct {
+		file     string
+		expected float64
+		err      error
+	}
+	tests := []test{
+		{"# 2 \"x.c\"\n\n", 1.23, fmt.Errorf("could not find file %s", "dummy.c")},
+		{"# 2 \"x.c\"\n\n# 1 \"dummy.c\"ff\nxxxxx\n\nyyyy", 1.23, fmt.Errorf("could not find %s:%d", "dummy.c", 5)},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = \nyyyy", 1.23, fmt.Errorf("cannot get exact value")},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = u\nyyyy", 1.23, fmt.Errorf("cannot parse float: strconv.ParseFloat: parsing \"\": invalid syntax from u")},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = 3.5zzz\nyyyy", 3.5, nil},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = .7\nyyyy", 0.7, nil},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = -.4e2\nyyyy", -40, nil},
+		{"# 2 \"x.c\"\n\n# 4 \"dummy.c\"ff\nxxxxx\nvar xyst = 0\nyyyy", 0, nil},
+	}
+	for _, test := range tests {
+		prepareRepairFromSourceTest(t, test.file, func(ppFilePath string) {
+			errors := RepairFloatingLiteralsFromSource(root, ppFilePath)
+			if fl.Value != test.expected {
+				t.Errorf("RepairFloatingLiteralsFromSource - expected: %f, got: %f", test.expected, fl.Value)
+			}
+			if test.err != nil && len(errors) == 0 || test.err == nil && len(errors) != 0 {
+				t.Errorf("RepairFloatingLiteralsFromSource - error should match: expected: %v, got: %v", test.err, errors)
+			} else if test.err != nil && errors[0].Err.Error() != test.err.Error() {
+				t.Errorf("RepairFloatingLiteralsFromSource - error should match: expected: %s, got: %s", test.err.Error(), errors[0].Err.Error())
+			}
+		})
+	}
 }

--- a/main.go
+++ b/main.go
@@ -261,6 +261,16 @@ func Start(args ProgramArgs) (err error) {
 	ast.FixPositions(tree)
 	p.SetNodes(tree)
 
+	// Repair the character literals. See RepairCharacterLiteralsFromSource for
+	// more information.
+	characterErrors := ast.RepairCharacterLiteralsFromSource(tree[0], ppFilePath)
+
+	for _, cErr := range characterErrors {
+		message := fmt.Sprintf("could not read exact character literal: %s",
+			cErr.Err.Error())
+		p.AddMessage(p.GenerateWarningMessage(errors.New(message), cErr.Node))
+	}
+
 	// Repair the floating literals. See RepairFloatingLiteralsFromSource for
 	// more information.
 	floatingErrors := ast.RepairFloatingLiteralsFromSource(tree[0], ppFilePath)

--- a/tests/cast.c
+++ b/tests/cast.c
@@ -81,9 +81,20 @@ void test_strCh()
 	is_eq(strlenChar(z),11);
 }
 
+typedef unsigned int pcre_uint32;
+#define CHAR_NBSP                   ((unsigned char)'\xa0')
+
+void test_preprocessor()
+{
+    int tmp = 160;
+    pcre_uint32 chr = tmp;
+
+    is_eq(chr, CHAR_NBSP);
+}
+
 int main()
 {
-    plan(29);
+    plan(30);
 
     START_TEST(cast);
     START_TEST(castbool);
@@ -170,6 +181,9 @@ int main()
 	}
 
 	char_overflow();
+
+    diag("Compare preprocessor with type")
+    test_preprocessor();
 
     done_testing();
 }


### PR DESCRIPTION
@cznic Thanks that helped.
My implementation differs from [charConst](https://github.com/cznic/sqlite2go/blob/6617e2aad08549d18787027028562d701f44cbb0/internal/c99/encoding.go#L302) in that it never panics, if there is a problem it returns an error.
Furthermore it supports all character literal prefixes from http://en.cppreference.com/w/cpp/language/character_literal
The last difference is that it reads octal/hex digits until either the first non-octal/hex character or until the maximum number of octal/hex digits is reached (http://en.cppreference.com/w/cpp/language/escape)
Multicharacter literals are not supported.

I added tests for the custom character literal parsing and `RepairCharacterLiteralsFromSource`.
The problematic c-code in #663 was added as an integration test in `cast.c`.

Finally, I changed `RepairFloatingLiteralsFromSource` to only set the node value if parsing the float succeeds without error, otherwise it adds a warning.
I also added tests for `RepairFloatingLiteralsFromSource`.

Fixes #663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/671)
<!-- Reviewable:end -->
