### PR TITLE
non_null_attr: tolerate the lack of 'A' in the AST

### DIFF
--- a/ast/non_null_attr.go
+++ b/ast/non_null_attr.go
@@ -23,9 +23,14 @@ func parseNonNullAttr(line string) *NonNullAttr {
 	groups := groupsFromRegex(
 		`<(?P<position>.*)>
 		(?P<inherited> Inherited)?
-		(?P<a> \d+)(?P<b> \d+)?(?P<c> \d+)?(?P<d> \d+)?`,
+		(?P<a> \d+)?(?P<b> \d+)?(?P<c> \d+)?(?P<d> \d+)?`,
 		line,
 	)
+
+	a := 0
+	if groups["a"] != "" {
+		a = util.Atoi(strings.TrimSpace(groups["a"]))
+	}
 
 	b := 0
 	if groups["b"] != "" {
@@ -46,7 +51,7 @@ func parseNonNullAttr(line string) *NonNullAttr {
 		Addr:       ParseAddress(groups["address"]),
 		Pos:        NewPositionFromString(groups["position"]),
 		Inherited:  len(groups["inherited"]) > 0,
-		A:          util.Atoi(strings.TrimSpace(groups["a"])),
+		A:          a,
 		B:          b,
 		C:          c,
 		D:          d,

--- a/ast/non_null_attr_test.go
+++ b/ast/non_null_attr_test.go
@@ -76,6 +76,16 @@ func TestNonNullAttr(t *testing.T) {
 			D:          0,
 			ChildNodes: []Node{},
 		},
+		`0x2c3d600 <line:304:19>`: &NonNullAttr{
+			Addr:       0x2c3d600,
+			Pos:        NewPositionFromString("line:304:19"),
+			Inherited:  false,
+			A:          0,
+			B:          0,
+			C:          0,
+			D:          0,
+			ChildNodes: []Node{},
+		},
 	}
 
 	runNodeTests(t, nodes)


### PR DESCRIPTION
Change regexp to tolerate 'A' being omitted.

The C source code that creates this is:

extern int blkid_probe_filter_superblocks_usage(blkid_probe pr, int flag, int usage)
			__ul_attribute__((nonnull));

Signed-off-by: Kevin Paul Herbert <kph@platinasystems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/695)
<!-- Reviewable:end -->
