### PR TITLE
warn_unused_result_attr: Add support for Inherited

### DIFF
--- a/ast/warn_unused_result_attr.go
+++ b/ast/warn_unused_result_attr.go
@@ -5,15 +5,17 @@ package ast
 type WarnUnusedResultAttr struct {
 	Addr       Address
 	Pos        Position
+	Inherited  bool
 	ChildNodes []Node
 }
 
 func parseWarnUnusedResultAttr(line string) *WarnUnusedResultAttr {
-	groups := groupsFromRegex(`<(?P<position>.*)>( warn_unused_result)?`, line)
+	groups := groupsFromRegex(`<(?P<position>.*)>(?P<inherited> Inherited)?( warn_unused_result)?`, line)
 
 	return &WarnUnusedResultAttr{
 		Addr:       ParseAddress(groups["address"]),
 		Pos:        NewPositionFromString(groups["position"]),
+		Inherited:  len(groups["inherited"]) > 0,
 		ChildNodes: []Node{},
 	}
 }

--- a/ast/warn_unused_result_attr_test.go
+++ b/ast/warn_unused_result_attr_test.go
@@ -9,11 +9,19 @@ func TestWarnUnusedResultAttr(t *testing.T) {
 		`0x7fa1d704d420 <col:60> warn_unused_result`: &WarnUnusedResultAttr{
 			Addr:       0x7fa1d704d420,
 			Pos:        NewPositionFromString("col:60"),
+			Inherited:  false,
 			ChildNodes: []Node{},
 		},
 		`0x1fac810 <line:481:52>`: &WarnUnusedResultAttr{
 			Addr:       0x1fac810,
 			Pos:        NewPositionFromString("line:481:52"),
+			Inherited:  false,
+			ChildNodes: []Node{},
+		},
+		`0x3794590 </home/kph/co/util-linux/libblkid/src/blkidP.h:374:19> Inherited`: &WarnUnusedResultAttr{
+			Addr:       0x3794590,
+			Pos:        NewPositionFromString("/home/kph/co/util-linux/libblkid/src/blkidP.h:374:19"),
+			Inherited:  true,
 			ChildNodes: []Node{},
 		},
 	}


### PR DESCRIPTION
WarnUsusedResult can have the Inherited attribute. This was generated
by the following C code:

extern char *blkid_get_cache_filename(struct blkid_config *conf)
			__attribute__((warn_unused_result));

Signed-off-by: Kevin Paul Herbert <kph@platinasystems.com>