### PR TITLE
Pass fixed-size arrays as slices. Fixes #736

### DIFF
--- a/noarch/stdio.go
+++ b/noarch/stdio.go
@@ -626,7 +626,7 @@ func Ftell(f *File) int32 {
 // read.
 //
 // The total amount of bytes read if successful is (size*count).
-func Fread(ptr *[]byte, size1, size2 int32, f *File) int32 {
+func Fread(ptr []byte, size1, size2 int32, f *File) int32 {
 	// Create a new buffer so that we can ensure we read up to the correct
 	// number of bytes from the file.
 	newBuffer := make([]byte, size1*size2)
@@ -635,7 +635,7 @@ func Fread(ptr *[]byte, size1, size2 int32, f *File) int32 {
 	// Despite any error we need to make sure the bytes read are copied to the
 	// destination buffer.
 	for i, b := range newBuffer {
-		(*ptr)[i] = b
+		ptr[i] = b
 	}
 
 	// Now we can handle the success or failure.

--- a/noarch/string.go
+++ b/noarch/string.go
@@ -145,20 +145,13 @@ func Strchr(str []byte, ch int32) []byte {
 // Memset treats dst as a binary array and sets size bytes to the value val.
 // Returns dst.
 func Memset(dst interface{}, val int32, size int32) interface{} {
-	v := reflect.ValueOf(dst)
-	vDst := v.Type()
+	vDst := reflect.ValueOf(dst).Type()
 	switch vDst.Kind() {
-	case reflect.Array:
-		// v might not be addressable
-		v2 := reflect.New(v.Type()).Elem()
-		v2.Set(v)
-		v = v2.Slice(0, v.Len())
-		fallthrough
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		vDst = vDst.Elem()
 	}
 	baseSizeDst := int32(vDst.Size())
-	data := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(v.Interface(), baseSizeDst, int32(1)))))[:]
+	data := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(dst, baseSizeDst, int32(1))))
 	var i int32
 	var vb = byte(val)
 	for i = 0; i < size; i++ {
@@ -174,34 +167,20 @@ func Memset(dst interface{}, val int32, size int32) interface{} {
 // To copy overlapping regions in C memmove should be used, so we map that function
 // to Memcpy as well.
 func Memcpy(dst interface{}, src interface{}, size int32) interface{} {
-	vD := reflect.ValueOf(dst)
-	vDst := vD.Type()
+	vDst := reflect.ValueOf(dst).Type()
 	switch vDst.Kind() {
-	case reflect.Array:
-		// vD might not be addressable
-		v2 := reflect.New(vD.Type()).Elem()
-		v2.Set(vD)
-		vD = v2.Slice(0, vD.Len())
-		fallthrough
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		vDst = vDst.Elem()
 	}
 	baseSizeDst := int32(vDst.Size())
-	vS := reflect.ValueOf(src)
-	vSrc := vS.Type()
+	vSrc := reflect.ValueOf(src).Type()
 	switch vSrc.Kind() {
-	case reflect.Array:
-		// vS might not be addressable
-		v2 := reflect.New(vS.Type()).Elem()
-		v2.Set(vS)
-		vS = v2.Slice(0, vS.Len())
-		fallthrough
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		vSrc = vSrc.Elem()
 	}
 	baseSizeSrc := int32(vSrc.Size())
-	bDst := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(vD.Interface(), baseSizeDst, int32(1)))))[:]
-	bSrc := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(vS.Interface(), baseSizeSrc, int32(1)))))[:]
+	bDst := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(dst, baseSizeDst, int32(1))))
+	bSrc := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src, baseSizeSrc, int32(1))))
 	copy(bDst[:size], bSrc[:size])
 	return dst
 }
@@ -221,7 +200,7 @@ func Memcmp(src1, src2 interface{}, n int32) int32 {
 		v2 = v2.Elem()
 	}
 	baseSize2 := int32(v2.Size())
-	b1 := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src1, baseSize1, int32(1)))))[:]
-	b2 := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src2, baseSize2, int32(1)))))[:]
+	b1 := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src1, baseSize1, int32(1))))
+	b2 := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src2, baseSize2, int32(1))))
 	return int32(bytes.Compare(b1[:int(n)], b2[:int(n)]))
 }

--- a/noarch/string.go
+++ b/noarch/string.go
@@ -145,13 +145,20 @@ func Strchr(str []byte, ch int32) []byte {
 // Memset treats dst as a binary array and sets size bytes to the value val.
 // Returns dst.
 func Memset(dst interface{}, val int32, size int32) interface{} {
-	vDst := reflect.ValueOf(dst).Type()
+	v := reflect.ValueOf(dst)
+	vDst := v.Type()
 	switch vDst.Kind() {
-	case reflect.Slice, reflect.Array:
+	case reflect.Array:
+		// v might not be addressable
+		v2 := reflect.New(v.Type()).Elem()
+		v2.Set(v)
+		v = v2.Slice(0, v.Len())
+		fallthrough
+	case reflect.Slice:
 		vDst = vDst.Elem()
 	}
 	baseSizeDst := int32(vDst.Size())
-	data := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(dst, baseSizeDst, int32(1))))
+	data := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(v.Interface(), baseSizeDst, int32(1)))))[:]
 	var i int32
 	var vb = byte(val)
 	for i = 0; i < size; i++ {
@@ -167,20 +174,34 @@ func Memset(dst interface{}, val int32, size int32) interface{} {
 // To copy overlapping regions in C memmove should be used, so we map that function
 // to Memcpy as well.
 func Memcpy(dst interface{}, src interface{}, size int32) interface{} {
-	vDst := reflect.ValueOf(dst).Type()
+	vD := reflect.ValueOf(dst)
+	vDst := vD.Type()
 	switch vDst.Kind() {
-	case reflect.Slice, reflect.Array:
+	case reflect.Array:
+		// vD might not be addressable
+		v2 := reflect.New(vD.Type()).Elem()
+		v2.Set(vD)
+		vD = v2.Slice(0, vD.Len())
+		fallthrough
+	case reflect.Slice:
 		vDst = vDst.Elem()
 	}
 	baseSizeDst := int32(vDst.Size())
-	vSrc := reflect.ValueOf(src).Type()
+	vS := reflect.ValueOf(src)
+	vSrc := vS.Type()
 	switch vSrc.Kind() {
-	case reflect.Slice, reflect.Array:
+	case reflect.Array:
+		// vS might not be addressable
+		v2 := reflect.New(vS.Type()).Elem()
+		v2.Set(vS)
+		vS = v2.Slice(0, vS.Len())
+		fallthrough
+	case reflect.Slice:
 		vSrc = vSrc.Elem()
 	}
 	baseSizeSrc := int32(vSrc.Size())
-	bDst := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(dst, baseSizeDst, int32(1))))
-	bSrc := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src, baseSizeSrc, int32(1))))
+	bDst := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(vD.Interface(), baseSizeDst, int32(1)))))[:]
+	bSrc := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(vS.Interface(), baseSizeSrc, int32(1)))))[:]
 	copy(bDst[:size], bSrc[:size])
 	return dst
 }
@@ -200,7 +221,7 @@ func Memcmp(src1, src2 interface{}, n int32) int32 {
 		v2 = v2.Elem()
 	}
 	baseSize2 := int32(v2.Size())
-	b1 := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src1, baseSize1, int32(1))))
-	b2 := *(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src2, baseSize2, int32(1))))
+	b1 := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src1, baseSize1, int32(1)))))[:]
+	b2 := (*(*[]byte)(unsafe.Pointer(UnsafeSliceToSlice(src2, baseSize2, int32(1)))))[:]
 	return int32(bytes.Compare(b1[:int(n)], b2[:int(n)]))
 }

--- a/program/function_definition.go
+++ b/program/function_definition.go
@@ -164,7 +164,7 @@ var builtInFunctionDefinitions = map[string][]string{
 		"int putc(int, FILE*) -> noarch.Fputc",
 		"int fseek(FILE*, long int, int) -> noarch.Fseek",
 		"long ftell(FILE*) -> noarch.Ftell",
-		"int fread(void*, int, int, FILE*) -> $0 = noarch.Fread(&1, $2, $3, $4)",
+		"int fread(void*, int, int, FILE*) -> noarch.Fread",
 		"int fwrite(char*, int, int, FILE*) -> noarch.Fwrite",
 		"int fgetpos(FILE*, int*) -> noarch.Fgetpos",
 		"int fsetpos(FILE*, int*) -> noarch.Fsetpos",

--- a/tests/string.c
+++ b/tests/string.c
@@ -9,10 +9,18 @@ typedef struct mem {
 typedef struct mem2 {
     int a[2];
 } mem2;
+typedef int altint;
+
+void setptr(int *arr, int val) {
+    arr[0] = val;
+}
+void setarr(int arr[], int val) {
+    arr[0] = val;
+}
 
 int main()
 {
-    plan(77);
+    plan(80);
 
     diag("TODO: __builtin_object_size")
     // https://github.com/elliotchance/c2go/issues/359
@@ -255,8 +263,14 @@ int main()
         is_eq(dest8.a[1], 0);
         dest8.a[0] = 42;
         mem2 dest9;
+        altint *test = (altint *) dest9.a;
         memcpy(dest9.a, dest8.a, sizeof(int)*2);
         is_eq(dest9.a[0], 42);
+        is_eq(test[0], 42);
+        setarr(dest9.a, 1);
+        is_eq(dest9.a[0], 1);
+        setptr(dest9.a, 2);
+        is_eq(dest9.a[0], 2);
     }
     {
         diag("memcmp");

--- a/tests/string.c
+++ b/tests/string.c
@@ -6,9 +6,13 @@ typedef struct mem {
     int b;
 } mem;
 
+typedef struct mem2 {
+    int a[2];
+} mem2;
+
 int main()
 {
-    plan(74);
+    plan(77);
 
     diag("TODO: __builtin_object_size")
     // https://github.com/elliotchance/c2go/issues/359
@@ -244,6 +248,15 @@ int main()
         is_eq(dest7[0].b, 3.0);
         is_eq(dest7[1].a, 0);
         is_eq(dest7[1].b, 0.0);
+        mem2 dest8;
+        dest8.a[0] = 42;
+        memset(dest8.a, 0, sizeof(int)*2);
+        is_eq(dest8.a[0], 0);
+        is_eq(dest8.a[1], 0);
+        dest8.a[0] = 42;
+        mem2 dest9;
+        memcpy(dest9.a, dest8.a, sizeof(int)*2);
+        is_eq(dest9.a[0], 42);
     }
     {
         diag("memcmp");

--- a/transpiler/call.go
+++ b/transpiler/call.go
@@ -207,9 +207,13 @@ func transpileCallExpr(n *ast.CallExpr, p *program.Program) (
 		var varName string
 		if v, ok := element[0].(*goast.Ident); ok {
 			varName = v.Name
-		} else {
-			return nil, "", nil, nil,
-				fmt.Errorf("golang ast for variable name have type %T, expect ast.Ident", element[3])
+		} else if se, ok := element[0].(*goast.SliceExpr); ok {
+			if v, ok2 := se.X.(*goast.Ident); ok2 {
+				varName = v.Name
+			} else {
+				return nil, "", nil, nil,
+					fmt.Errorf("golang ast for variable name have type %T, expect ast.Ident", element[0])
+			}
 		}
 
 		p.AddImport("sort")

--- a/transpiler/cast.go
+++ b/transpiler/cast.go
@@ -59,7 +59,7 @@ func transpileImplicitCastExpr(n *ast.ImplicitCastExpr, p *program.Program, expr
 		return
 	}
 
-	if !types.IsFunction(exprType) {
+	if !types.IsFunction(exprType) && !strings.ContainsAny(n.Type, "[]") {
 		expr, err = types.CastExpr(p, expr, exprType, n.Type)
 		if err != nil {
 			return nil, "", nil, nil, err

--- a/transpiler/cast.go
+++ b/transpiler/cast.go
@@ -59,7 +59,7 @@ func transpileImplicitCastExpr(n *ast.ImplicitCastExpr, p *program.Program, expr
 		return
 	}
 
-	if !types.IsFunction(exprType) && n.Kind != ast.ImplicitCastExprArrayToPointerDecay {
+	if !types.IsFunction(exprType) {
 		expr, err = types.CastExpr(p, expr, exprType, n.Type)
 		if err != nil {
 			return nil, "", nil, nil, err

--- a/transpiler/variables.go
+++ b/transpiler/variables.go
@@ -370,6 +370,11 @@ func transpileArraySubscriptExpr(n *ast.ArraySubscriptExpr, p *program.Program, 
 	}
 	preStmts, postStmts = combinePreAndPostStmts(preStmts, postStmts, newPre, newPost)
 
+	if se, ok := expression.(*goast.SliceExpr); ok && se.High == nil && se.Low == nil && se.Max == nil {
+		// simplify the expression
+		expression = se.X
+	}
+
 	isConst, indexInt := util.EvaluateConstExpr(index)
 	if isConst && indexInt < 0 {
 		indexInt = -indexInt

--- a/types/cast.go
+++ b/types/cast.go
@@ -490,6 +490,9 @@ func CastExpr(p *program.Program, expr goast.Expr, cFromType, cToType string) (
 		if err != nil {
 			return nil, err
 		}
+		if _, arrSize := GetArrayTypeAndSize(cFromType); arrSize > 0 {
+			expr = &goast.SliceExpr{X: expr}
+		}
 		return &goast.StarExpr{
 			X: &goast.CallExpr{
 				Fun: &goast.StarExpr{


### PR DESCRIPTION
When passing arrays of fixed length around as parameters, Go passes them by value, making a copy.
Any changes to the copied array will not change the initial array values. To have the same behaviour as in C, we need to always pass arrays as slices.
This is also required for calls to library functions like `UnsafeSliceToSlice` and `Fread`.
Fixes #736

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/737)
<!-- Reviewable:end -->
