### PR TITLE
Swap of complement uses copied nodes. Fixes #746

### DIFF
--- a/tests/operators.c
+++ b/tests/operators.c
@@ -45,10 +45,12 @@ typedef unsigned char pcre_uint8;
 typedef unsigned char pcre_uchar;
 #define UCHAR21INCTEST(eptr) (*(eptr)++)
 #define PCRE_PUCHAR const pcre_uchar *
+#define PREP_A 0x0002
+#define PREP_B 0x0010
 
 int main()
 {
-	plan(139);
+	plan(140);
 
     int i = 10;
     signed char j = 1;
@@ -496,6 +498,12 @@ int main()
         is_eq(*p2, 'z');
         is_eq(pp, 'z');
         is_eq(pp2, 'b');
+    }
+    diag("Test complement");
+    {
+        unsigned long int flags = 32;
+        flags &= ~(PREP_A|PREP_B);
+        is_eq(flags, 32);
     }
 
 	done_testing();

--- a/transpiler/cast.go
+++ b/transpiler/cast.go
@@ -87,11 +87,15 @@ func swapCastAndComplement(n *ast.ImplicitCastExpr, p *program.Program, exprIsSt
 	postStmts []goast.Stmt,
 	err error) {
 	uo := n.Children()[0].(*ast.UnaryOperator)
+	copyUnary := &ast.UnaryOperator{}
+	copyImplicit := &ast.ImplicitCastExpr{}
+	*copyUnary = *uo
+	*copyImplicit = *n
 	unaryChildren := uo.ChildNodes
-	uo.ChildNodes = []ast.Node{n}
-	uo.Type = n.Type
-	n.ChildNodes = unaryChildren
-	return transpileToExpr(uo, p, exprIsStmt)
+	copyUnary.ChildNodes = []ast.Node{copyImplicit}
+	copyUnary.Type = copyImplicit.Type
+	copyImplicit.ChildNodes = unaryChildren
+	return transpileToExpr(copyUnary, p, exprIsStmt)
 }
 
 func transpileCStyleCastExpr(n *ast.CStyleCastExpr, p *program.Program, exprIsStmt bool) (


### PR DESCRIPTION
Using copied nodes makes it so that if the swapped nodes are transpiled in
a 2 pass process, that during the 2nd pass the swap can be executed.

Fixes #746

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/747)
<!-- Reviewable:end -->
