### PR TITLE
Load fileCache on Windows. Fixes #775

### DIFF
--- a/cc/preprocessor.go
+++ b/cc/preprocessor.go
@@ -49,7 +49,9 @@ func GetLineFromPreprocessedFile(inputFilePath, filePath string, lineNumber int)
 				}
 
 				currentLine = util.Atoi(matches[1])
-				currentFile = matches[2]
+
+				// unescape windows file paths
+				currentFile = strings.Replace(matches[2], "\\\\", "\\", -1)
 
 				if _, ok := fileCache[currentFile]; !ok {
 					fileCache[currentFile] = map[int]string{}


### PR DESCRIPTION
Backslashes needed to be unescaped, otherwise the file would not be found in the cache later on.

Fixes #775

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/776)
<!-- Reviewable:end -->
