### PR TITLE
Improve speed of bool-to-int conversions

### DIFF
--- a/types/cast.go
+++ b/types/cast.go
@@ -366,9 +366,9 @@ func CastExpr(p *program.Program, expr goast.Expr, cFromType, cToType string) (
 			return e, nil
 		}
 		if fromType == "bool" && toType == v {
-			e := util.NewGoExpr(`map[bool]int32{false: 0, true: 1}[replaceme]`)
+			e := util.NewGoExpr(`func(val bool) int32 { if val { return 1 } else { return 0 } }(replaceme)`)
 			// Swap replaceme with the current expression
-			e.(*goast.IndexExpr).Index = expr
+			e.(*goast.CallExpr).Args = []goast.Expr{expr}
 			return CastExpr(p, e, "int", cToType)
 		}
 	}


### PR DESCRIPTION
Use a simple function that tests the bool and returns 0 for false and
1 for true, rather than a map that does the same thing, as Go appears
to compile the former into much faster code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/796)
<!-- Reviewable:end -->
