### PR TITLE
Skip unnecessary conversion. Fixes #805

### DIFF
--- a/types/cast.go
+++ b/types/cast.go
@@ -486,8 +486,6 @@ func CastExpr(p *program.Program, expr goast.Expr, cFromType, cToType string) (
 		}, nil
 	}
 
-	p.AddImport("github.com/elliotchance/c2go/noarch")
-
 	if strings.HasPrefix(toType, "[]") && strings.HasPrefix(fromType, "*") && isArrayToPointerExpr(expr) {
 		expr = extractArrayFromPointer(expr)
 		fromType = "[]" + fromType[1:]
@@ -507,6 +505,13 @@ func CastExpr(p *program.Program, expr goast.Expr, cFromType, cToType string) (
 	if cFromType == "void *" && cToType == "char *" {
 		return expr, nil
 	}
+
+	if toType == fromType {
+		return expr, nil
+	}
+
+	p.AddImport("github.com/elliotchance/c2go/noarch")
+	p.AddImport("unsafe")
 
 	exportedLeftName := util.GetExportedName(leftName)
 	exportedRightName := util.GetExportedName(rightName)


### PR DESCRIPTION
In processing a type conversion, the extractArrayFromPointer step can
result in fromType and toType being the same. So we should check them
for equality again, and skip the conversion if they are equal.

Fixes #805

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/806)
<!-- Reviewable:end -->
