### PR TITLE
Resolve const struct types. Fixes #807

### DIFF
--- a/transpiler/variables.go
+++ b/transpiler/variables.go
@@ -417,6 +417,7 @@ func transpileMemberExpr(n *ast.MemberExpr, p *program.Program) (
 	}
 
 	lhsType = types.GenerateCorrectType(lhsType)
+	lhsType = types.CleanCType(lhsType)
 
 	preStmts, postStmts = combinePreAndPostStmts(preStmts, postStmts, newPre, newPost)
 


### PR DESCRIPTION
Call CleanCType before searching for a matching struct. This gets rid of
the const qualifier.

Fixes #807

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/808)
<!-- Reviewable:end -->
