### PR TITLE
handle "part_of_explicit_cast" + "cannot overflow"

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@
 package ast
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -283,7 +284,7 @@ func groupsFromRegex(rx, line string) map[string]string {
 
 	match := re.FindStringSubmatch(line)
 	if len(match) == 0 {
-		panic("could not match regexp with string\n" + rx + "\n" + line + "\n")
+		panic(fmt.Sprintf("could not match regexp %q for %q", rx, line))
 	}
 
 	result := make(map[string]string)

--- a/ast/implicit_cast_expr.go
+++ b/ast/implicit_cast_expr.go
@@ -15,10 +15,10 @@ const ImplicitCastExprArrayToPointerDecay = "ArrayToPointerDecay"
 
 func parseImplicitCastExpr(line string) *ImplicitCastExpr {
 	groups := groupsFromRegex(
-		`<(?P<position>.*)>
-		 '(?P<type>.*?)'
-		(:'(?P<type2>.*?)')?
-		 <(?P<kind>.*)>`,
+		`<(?P<position>[^>]*)>
+		 '(?P<type>[^']*?)'
+		(:'(?P<type2>[^']*?)')?
+		 <(?P<kind>[^>]*)>( part_of_explicit_cast)?`,
 		line,
 	)
 

--- a/ast/unary_operator.go
+++ b/ast/unary_operator.go
@@ -14,12 +14,13 @@ type UnaryOperator struct {
 
 func parseUnaryOperator(line string) *UnaryOperator {
 	groups := groupsFromRegex(
-		`<(?P<position>.*)>
-		 '(?P<type>.*?)'(:'(?P<type2>.*)')?
+		`<(?P<position>[^>]*)>
+		 '(?P<type>[^']*?)'(:'(?P<type2>.*)')?
 		(?P<lvalue> lvalue)?
 		(?P<prefix> prefix)?
 		(?P<postfix> postfix)?
-		 '(?P<operator>.*?)'`,
+		 '(?P<operator>[^']*?)'
+		(?P<overflow>( cannot)? overflow)?`,
 		line,
 	)
 


### PR DESCRIPTION
And better panic message (use %q to separate regexp from line).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/818)
<!-- Reviewable:end -->
