### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/program/program.go
+++ b/program/program.go
@@ -421,7 +421,7 @@ func (p *Program) String() string {
 	return string(reg.ReplaceAll(buf.Bytes(), []byte("interface {}")))
 }
 
-// IncudeHeaderIsExist - return true if C #include header is inside list
+// IncludeHeaderIsExists - return true if C #include header is inside list
 func (p *Program) IncludeHeaderIsExists(includeHeader string) bool {
 	for _, inc := range p.IncludeHeaders {
 		if strings.HasSuffix(inc.HeaderName, includeHeader) {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/819)
<!-- Reviewable:end -->
