### PR TITLE
Add support for NoDebugAttr

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -176,6 +176,8 @@ func Parse(fullline string) Node {
 		return parseModeAttr(line)
 	case "NoAliasAttr":
 		return parseNoAliasAttr(line)
+	case "NoDebugAttr":
+		return parseNoDebugAttr(line)
 	case "NoInlineAttr":
 		return parseNoInlineAttr(line)
 	case "NoThrowAttr":

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -58,7 +58,7 @@ func TestPrint(t *testing.T) {
 }
 
 var lines = []string{
-// c2go ast sqlite3.c | head -5000 | sed 's/^[ |`-]*//' | sed 's/<<<NULL>>>/NullStmt/g' | gawk 'length > 0 {print "`" $0 "`,"}'
+	// c2go ast sqlite3.c | head -5000 | sed 's/^[ |`-]*//' | sed 's/<<<NULL>>>/NullStmt/g' | gawk 'length > 0 {print "`" $0 "`,"}'
 }
 
 func BenchmarkParse(b *testing.B) {

--- a/ast/no_debug_attr.go
+++ b/ast/no_debug_attr.go
@@ -1,0 +1,45 @@
+package ast
+
+// NoDebugAttr is a type of attribute that is optionally attached to a variable
+// or struct field definition.
+type NoDebugAttr struct {
+	Addr       Address
+	Pos        Position
+	ChildNodes []Node
+}
+
+func parseNoDebugAttr(line string) *NoDebugAttr {
+	groups := groupsFromRegex(
+		`<(?P<position>.*)>`,
+		line,
+	)
+
+	return &NoDebugAttr{
+		Addr:       ParseAddress(groups["address"]),
+		Pos:        NewPositionFromString(groups["position"]),
+		ChildNodes: []Node{},
+	}
+}
+
+// AddChild adds a new child node. Child nodes can then be accessed with the
+// Children attribute.
+func (n *NoDebugAttr) AddChild(node Node) {
+	n.ChildNodes = append(n.ChildNodes, node)
+}
+
+// Address returns the numeric address of the node. See the documentation for
+// the Address type for more information.
+func (n *NoDebugAttr) Address() Address {
+	return n.Addr
+}
+
+// Children returns the child nodes. If this node does not have any children or
+// this node does not support children it will always return an empty slice.
+func (n *NoDebugAttr) Children() []Node {
+	return n.ChildNodes
+}
+
+// Position returns the position in the original source code.
+func (n *NoDebugAttr) Position() Position {
+	return n.Pos
+}

--- a/ast/no_debug_attr_test.go
+++ b/ast/no_debug_attr_test.go
@@ -1,0 +1,17 @@
+package ast
+
+import (
+	"testing"
+)
+
+func TestNoDebugAttr(t *testing.T) {
+	nodes := map[string]Node{
+		`0x33b8788 <col:59>`: &NoDebugAttr{
+			Addr:       0x33b8788,
+			Pos:        NewPositionFromString("col:59"),
+			ChildNodes: []Node{},
+		},
+	}
+
+	runNodeTests(t, nodes)
+}

--- a/ast/position.go
+++ b/ast/position.go
@@ -337,6 +337,8 @@ func setPosition(node Node, position Position) {
 		n.Pos = position
 	case *NoAliasAttr:
 		n.Pos = position
+	case *NoDebugAttr:
+		n.Pos = position
 	case *NoInlineAttr:
 		n.Pos = position
 	case *NoThrowAttr:


### PR DESCRIPTION
Fixes `panic: unknown node type: 'NoDebugAttr 0x2ebd788 <col:59>'`
