### PR TITLE
ast: add ConstantExpr

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -92,6 +92,8 @@ func Parse(fullline string) Node {
 		return parseConstAttr(line)
 	case "ConstantArrayType":
 		return parseConstantArrayType(line)
+	case "ConstantExpr":
+		return parseConstantExpr(line)
 	case "ContinueStmt":
 		return parseContinueStmt(line)
 	case "CompoundAssignOperator":

--- a/ast/constant_expr.go
+++ b/ast/constant_expr.go
@@ -1,0 +1,46 @@
+package ast
+
+// ConstantExpr is a constant expression
+type ConstantExpr struct {
+	Addr       Address
+	Pos        Position
+	Type       string
+	ChildNodes []Node
+}
+
+func parseConstantExpr(line string) *ConstantExpr {
+	groups := groupsFromRegex(
+		"<(?P<position>.*)> '(?P<type>.*?)'",
+		line,
+	)
+
+	return &ConstantExpr{
+		Addr:       ParseAddress(groups["address"]),
+		Pos:        NewPositionFromString(groups["position"]),
+		Type:       groups["type"],
+		ChildNodes: []Node{},
+	}
+}
+
+// AddChild adds a new child node. Child nodes can then be accessed with the
+// Children attribute.
+func (n *ConstantExpr) AddChild(node Node) {
+	n.ChildNodes = append(n.ChildNodes, node)
+}
+
+// Address returns the numeric address of the node. See the documentation for
+// the Address type for more information.
+func (n *ConstantExpr) Address() Address {
+	return n.Addr
+}
+
+// Children returns the child nodes. If this node does not have any children or
+// this node does not support children it will always return an empty slice.
+func (n *ConstantExpr) Children() []Node {
+	return n.ChildNodes
+}
+
+// Position returns the position in the original source code.
+func (n *ConstantExpr) Position() Position {
+	return n.Pos
+}

--- a/ast/constant_expr_test.go
+++ b/ast/constant_expr_test.go
@@ -1,0 +1,18 @@
+package ast
+
+import (
+	"testing"
+)
+
+func TestConstantExpr(t *testing.T) {
+	nodes := map[string]Node{
+		`0x5558ffde68f0 <col:34, col:55> 'unsigned long'`: &ConstantExpr{
+			Addr:       0x5558ffde68f0,
+			Pos:        NewPositionFromString("col:34, col:55"),
+			Type:       "unsigned long",
+			ChildNodes: []Node{},
+		},
+	}
+
+	runNodeTests(t, nodes)
+}

--- a/ast/position.go
+++ b/ast/position.go
@@ -263,6 +263,8 @@ func setPosition(node Node, position Position) {
 		n.Pos = position
 	case *ConstAttr:
 		n.Pos = position
+	case *ConstantExpr:
+		n.Pos = position
 	case *ContinueStmt:
 		n.Pos = position
 	case *CompoundAssignOperator:


### PR DESCRIPTION
c2go is now capable of parsing stddef.h (of Clang) on Linux.

Fixes #829.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/830)
<!-- Reviewable:end -->
