### PR TITLE
transpiler: support IfStmt representation of Clang 9.0

### DIFF
--- a/ast/if_stmt.go
+++ b/ast/if_stmt.go
@@ -4,18 +4,20 @@ package ast
 type IfStmt struct {
 	Addr       Address
 	Pos        Position
+	HasElse    bool
 	ChildNodes []Node
 }
 
 func parseIfStmt(line string) *IfStmt {
 	groups := groupsFromRegex(
-		"<(?P<position>.*)>",
+		"<(?P<position>.*)>(?P<has_else> has_else)?",
 		line,
 	)
 
 	return &IfStmt{
 		Addr:       ParseAddress(groups["address"]),
 		Pos:        NewPositionFromString(groups["position"]),
+		HasElse:    len(groups["has_else"]) > 0,
 		ChildNodes: []Node{},
 	}
 }

--- a/ast/if_stmt_test.go
+++ b/ast/if_stmt_test.go
@@ -11,6 +11,12 @@ func TestIfStmt(t *testing.T) {
 			Pos:        NewPositionFromString("line:11:7, line:18:7"),
 			ChildNodes: []Node{},
 		},
+		`0x560d43f4ee98 <line:65:2, line:72:2> has_else`: &IfStmt{
+			Addr:       0x560d43f4ee98,
+			Pos:        NewPositionFromString("line:65:2, line:72:2"),
+			HasElse:    true,
+			ChildNodes: []Node{},
+		},
 	}
 
 	runNodeTests(t, nodes)

--- a/transpiler/branch.go
+++ b/transpiler/branch.go
@@ -46,6 +46,7 @@ func transpileIfStmt(n *ast.IfStmt, p *program.Program) (
 	//
 	// 1. conditional = BinaryOperator: i == 0
 	// 2. body = CompoundStmt: { return 0; }
+	// 3. (optional) else-body = CompoundStmt: { return 1; }
 
 	// On linux I have seen only 4 children for an IfStmt with the same
 	// definitions above, but missing the first argument. Since we don't


### PR DESCRIPTION
Prior to this commit, the transpileIfStmt logic of c2go relied on the
assumption that if-statements always have 4 (or 5) children. With recent
versions of Clang, this assumption no longer holds.

Therefore, this commit relaxes the assumption by simply trimming the
first two child nodes if the IfStmt has 5 children, and the first child
node if the IfStmt has 4 children, respectively.

The later logic is adjusted to always use children[0] for the
conditional node, children[1] for the if-body node and optionally
children[2] for the else-body node (if present).

Fixes #833.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/834)
<!-- Reviewable:end -->
