### PR TITLE
Handle wide-character string literals in regex

### DIFF
--- a/ast/string_literal.go
+++ b/ast/string_literal.go
@@ -17,7 +17,7 @@ type StringLiteral struct {
 
 func parseStringLiteral(line string) *StringLiteral {
 	groups := groupsFromRegex(
-		`<(?P<position>.*)> '(?P<type>.*)'(?P<lvalue> lvalue)? (?P<value>".*")`,
+		`<(?P<position>.*)> '(?P<type>.*)'(?P<lvalue> lvalue)? L?(?P<value>".*")`,
 		line,
 	)
 

--- a/ast/string_literal_test.go
+++ b/ast/string_literal_test.go
@@ -30,6 +30,14 @@ func TestStringLiteral(t *testing.T) {
 			Value:      "foo",
 			ChildNodes: []Node{},
 		},
+		`0x61b80c8 <col:19> 'wchar_t [21]' lvalue L"hello$$\x4F60\x597D\242\242\x4E16\x754C\x20AC\x20ACworld"`: &StringLiteral{
+			Addr:       0x61b80c8,
+			Pos:        NewPositionFromString("col:19"),
+			Type:       "wchar_t [21]",
+			Lvalue:     true,
+			Value:      "hello$$\x4F60\x597D\242\242\x4E16\x754C\x20AC\x20ACworld",
+			ChildNodes: []Node{},
+		},
 	}
 
 	runNodeTests(t, nodes)


### PR DESCRIPTION
Fixes #866

Does not add support for wide-character strings per se, only for parsing the clang AST without crashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/867)
<!-- Reviewable:end -->
