### PR TITLE
ignore keywords when part of a variable name

### DIFF
--- a/types/resolve.go
+++ b/types/resolve.go
@@ -574,7 +574,7 @@ func ParseFunction(s string) (f []string, r []string, err error) {
 var (
 	rxconst      = regexp.MustCompile(`\bconst\b`)
 	rxvolatile   = regexp.MustCompile(`\bvolatile\b`)
-	rx__restrict = regexp.MustCompile(`\b__restrict\b`)
+	rxUUrestrict = regexp.MustCompile(`\b__restrict\b`)
 	rxrestrict   = regexp.MustCompile(`\brestrict\b`)
 )
 
@@ -593,7 +593,7 @@ func CleanCType(s string) (out string) {
 	// Remove any whitespace or attributes that are not relevant to Go.
 	out = rxconst.ReplaceAllLiteralString(out, "")
 	out = rxvolatile.ReplaceAllLiteralString(out, "")
-	out = rx__restrict.ReplaceAllLiteralString(out, "")
+	out = rxUUrestrict.ReplaceAllLiteralString(out, "")
 	out = rxrestrict.ReplaceAllLiteralString(out, "")
 	out = strings.Replace(out, "\t", "", -1)
 	out = strings.Replace(out, "\n", "", -1)

--- a/types/resolve.go
+++ b/types/resolve.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -570,6 +571,13 @@ func ParseFunction(s string) (f []string, r []string, err error) {
 	return
 }
 
+var (
+	rxconst      = regexp.MustCompile(`\bconst\b`)
+	rxvolatile   = regexp.MustCompile(`\bvolatile\b`)
+	rx__restrict = regexp.MustCompile(`\b__restrict\b`)
+	rxrestrict   = regexp.MustCompile(`\brestrict\b`)
+)
+
 // CleanCType - remove from C type not Go type
 func CleanCType(s string) (out string) {
 	out = s
@@ -583,10 +591,10 @@ func CleanCType(s string) (out string) {
 	out = strings.Replace(out, "( *)", "(*)", -1)
 
 	// Remove any whitespace or attributes that are not relevant to Go.
-	out = strings.Replace(out, "const", "", -1)
-	out = strings.Replace(out, "volatile", "", -1)
-	out = strings.Replace(out, "__restrict", "", -1)
-	out = strings.Replace(out, "restrict", "", -1)
+	out = rxconst.ReplaceAllLiteralString(out, "")
+	out = rxvolatile.ReplaceAllLiteralString(out, "")
+	out = rx__restrict.ReplaceAllLiteralString(out, "")
+	out = rxrestrict.ReplaceAllLiteralString(out, "")
 	out = strings.Replace(out, "\t", "", -1)
 	out = strings.Replace(out, "\n", "", -1)
 	out = strings.Replace(out, "\r", "", -1)


### PR DESCRIPTION
Fixes #886.

An integration test fails, but it also fails on master.
```console
$ go test -tags=integration ./...
panic: unknown node type: 'BuiltinAttr 0x556db52386a0 <<invalid sloc>> Inherited Implicit 946'

goroutine 148 [running]:
github.com/elliotchance/c2go/ast.Parse(0xc0003bcbd3, 0x42, 0x70ad6f, 0x5)
        /github.com/elliotchance/c2go/ast/ast.go:294 +0x354b
github.com/elliotchance/c2go.convertLinesToNodes(0xc0000a7a20, 0x1d, 0xec1, 0x0, 0x0, 0x0)
        /github.com/elliotchance/c2go/main.go:89 +0x1b4
github.com/elliotchance/c2go.convertLinesToNodesParallel.func1.2(0xc000682120, 0xc000328010, 0xc0000a7a20, 0x1d, 0xec1, 0x0)
        /github.com/elliotchance/c2go/main.go:121 +0x53
created by github.com/elliotchance/c2go.convertLinesToNodesParallel.func1
        /github.com/elliotchance/c2go/main.go:119 +0x1be
FAIL    github.com/elliotchance/c2go    0.204s
ok      github.com/elliotchance/c2go/ast        (cached)
?       github.com/elliotchance/c2go/cc [no test files]
?       github.com/elliotchance/c2go/darwin     [no test files]
?       github.com/elliotchance/c2go/linux      [no test files]
ok      github.com/elliotchance/c2go/noarch     (cached)
ok      github.com/elliotchance/c2go/preprocessor       (cached)
?       github.com/elliotchance/c2go/program    [no test files]
ok      github.com/elliotchance/c2go/transpiler (cached)
ok      github.com/elliotchance/c2go/types      (cached)
ok      github.com/elliotchance/c2go/util       (cached)
FAIL
```
```console
$ clang --version
clang version 12.0.1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm/12/bin
$ go version
go version go1.16.2 linux/amd64
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/c2go/887)
<!-- Reviewable:end -->
